### PR TITLE
Change backup retention to 35 days

### DIFF
--- a/templates/postgresql-server.json
+++ b/templates/postgresql-server.json
@@ -44,7 +44,7 @@
       "properties": {
         "storageProfile": {
           "storageMB": "[parameters('postgresSku').size]",
-          "backupRetentionDays": 7,
+          "backupRetentionDays": 35,
           "geoRedundantBackup": "Disabled"
         },
         "version": "9.6",


### PR DESCRIPTION
Increase backup retention in template to 35 days. Previous max used to be 7.