### PR TITLE
Added a new appServiceState parameter and web app state in prop

### DIFF
--- a/templates/app-service-windows.json
+++ b/templates/app-service-windows.json
@@ -41,7 +41,14 @@
     },
     "appServiceState": {
       "type": "string",
-      "defaultValue": "Running"
+      "defaultValue": "Running",
+      "allowedvalues": [
+        "Stopped",
+        "Running"
+      ],
+      "metadata": {
+        "description": "State of the app service when deployed."
+      }
     },
     "deployStagingSlot": {
       "type": "bool",
@@ -73,7 +80,7 @@
         "serverFarmId": "[variables('appServicePlanId')]",
         "clientAffinityEnabled": false,
         "httpsOnly": true,
-        "state":  "[parameters('appServiceState')]",
+        "state": "[parameters('appServiceState')]",
         "siteConfig": {
           "alwaysOn": true,
           "appSettings": "[parameters('appServiceAppSettings')]",

--- a/templates/app-service-windows.json
+++ b/templates/app-service-windows.json
@@ -42,7 +42,7 @@
     "appServiceState": {
       "type": "string",
       "defaultValue": "Running",
-      "allowedvalues": [
+      "allowedValues": [
         "Stopped",
         "Running"
       ],

--- a/templates/app-service-windows.json
+++ b/templates/app-service-windows.json
@@ -39,6 +39,10 @@
         "description": "This can be passed into the template via the reference function: [reference(resourceId(parameters('certificateResourceGroup'), 'Microsoft.Web/certificates', parameters('certificateName')), '2016-03-01').Thumbprint]"
       }
     },
+    "appServiceState": {
+      "type": "string",
+      "defaultValue": "Running"
+    },
     "deployStagingSlot": {
       "type": "bool",
       "defaultValue": true
@@ -69,6 +73,7 @@
         "serverFarmId": "[variables('appServicePlanId')]",
         "clientAffinityEnabled": false,
         "httpsOnly": true,
+        "state":  "[parameters('appServiceState')]",
         "siteConfig": {
           "alwaysOn": true,
           "appSettings": "[parameters('appServiceAppSettings')]",


### PR DESCRIPTION
- Added a appservicestate parameter to the app-service-windows.json which sets a desired app service state during deployment (i.e. stopped,running). Default is set a running. This would facilitate worker apps to be deployed in a stopped state.
- Added a state property for webapps.