### PR TITLE
Creating conditional slot deployment

### DIFF
--- a/templates/app-service-linux.json
+++ b/templates/app-service-linux.json
@@ -44,6 +44,13 @@
       "metadata": {
         "description": "This can be passed into the template via the reference function: [reference(resourceId(parameters('certificateResourceGroup'), 'Microsoft.Web/certificates', parameters('certificateName')), '2016-03-01').Thumbprint]"
       }
+    },
+    "deploymentUsingSlots":{
+      "type": "bool",
+      "defaultValue": true,
+      "metadata": {
+        "description": "Conditional use of slots when deploying webapp"
+      }
     }
   },
   "variables": {
@@ -52,6 +59,28 @@
   },
   "resources": [
     {
+      "condition": "[equals(parameters('deploymentUsingSlots'), false)]",
+
+      "apiVersion": "2016-08-01",
+      "name": "[parameters('appServiceName')]",
+      "type": "Microsoft.Web/sites",
+      "kind": "app,linux,container",
+      "location": "[resourceGroup().location]",
+      "dependsOn": ["app-service-plan", "database", "database-server"],
+      "properties": {
+        "httpsOnly": true,
+        "serverFarmId": "[variables('appServicePlanId')]",
+        "clientAffinityEnabled": false,
+        "siteConfig": {
+          "alwaysOn": false,
+          "linuxFxVersion": "[variables('appServiceRuntimeStack')]",
+          "appSettings": "[parameters('appServiceAppSettings')]",
+          "connectionStrings": "[parameters('appServiceConnectionStrings')]"
+        }
+      }
+    },
+    {
+      "condition": "[equals(parameters('deploymentUsingSlots'), true)]",
       "type": "Microsoft.Web/sites",
       "name": "[parameters('appServiceName')]",
       "kind": "app,linux,container",

--- a/templates/app-service-linux.json
+++ b/templates/app-service-linux.json
@@ -45,34 +45,42 @@
         "description": "This can be passed into the template via the reference function: [reference(resourceId(parameters('certificateResourceGroup'), 'Microsoft.Web/certificates', parameters('certificateName')), '2016-03-01').Thumbprint]"
       }
     },
-    "deploymentUsingSlots":{
+    "deploymentUsingSlots": {
       "type": "bool",
       "defaultValue": true,
       "metadata": {
         "description": "Conditional use of slots when deploying webapp"
       }
+    },
+    "webappAlwaysOn": {
+      "type": "bool",
+      "defaultValue": true
+    },
+    "webappSlotAlwaysOn": {
+      "type": "bool",
+      "defaultValue": false
     }
   },
   "variables": {
     "appServicePlanId": "[resourceId(parameters('appServicePlanResourceGroup'), 'Microsoft.Web/serverfarms', parameters('appServicePlanName'))]",
-    "useCustomHostname": "[greater(length(parameters('customHostname')), 0)]"
+    "useCustomHostname": "[greater(length(parameters('customHostname')), 0)]",
+    "appServiceHttpsOnly": true,
+    "appServiceClientAffinityEnabled": false
   },
   "resources": [
     {
       "condition": "[equals(parameters('deploymentUsingSlots'), false)]",
-
       "apiVersion": "2016-08-01",
       "name": "[parameters('appServiceName')]",
       "type": "Microsoft.Web/sites",
       "kind": "app,linux,container",
       "location": "[resourceGroup().location]",
-      "dependsOn": ["app-service-plan", "database", "database-server"],
       "properties": {
-        "httpsOnly": true,
+        "httpsOnly": "[variables('appServiceHttpsOnly')]",
         "serverFarmId": "[variables('appServicePlanId')]",
-        "clientAffinityEnabled": false,
+        "clientAffinityEnabled": "[variables('appServiceClientAffinityEnabled')]",
         "siteConfig": {
-          "alwaysOn": false,
+          "alwaysOn": "[parameters('webappAlwaysOn')]",
           "linuxFxVersion": "[variables('appServiceRuntimeStack')]",
           "appSettings": "[parameters('appServiceAppSettings')]",
           "connectionStrings": "[parameters('appServiceConnectionStrings')]"
@@ -87,14 +95,14 @@
       "apiVersion": "2016-08-01",
       "location": "[resourceGroup().location]",
       "properties": {
-        "clientAffinityEnabled": false,
+        "clientAffinityEnabled": "[variables('appServiceClientAffinityEnabled')]",
         "serverFarmId": "[variables('appServicePlanId')]",
         "siteConfig": {
-          "alwaysOn": true,
+          "alwaysOn": "[parameters('webappAlwaysOn')]",
           "appSettings": "[parameters('appServiceAppSettings')]",
           "connectionStrings": "[parameters('appServiceConnectionStrings')]"
         },
-        "httpsOnly": true
+        "httpsOnly": "[variables('appServiceHttpsOnly')]"
       },
       "resources": [
         {
@@ -103,15 +111,15 @@
           "apiVersion": "2016-08-01",
           "location": "[resourceGroup().location]",
           "properties": {
-            "clientAffinityEnabled": false,
+            "clientAffinityEnabled": "[variables('appServiceClientAffinityEnabled')]",
             "serverFarmId": "[variables('appServicePlanId')]",
             "siteConfig": {
-              "alwaysOn": false,
+              "alwaysOn": "[parameters('webappSlotAlwaysOn')]",
               "linuxFxVersion": "[parameters('runtimeStack')]",
               "appSettings": "[parameters('appServiceAppSettings')]",
               "connectionStrings": "[parameters('appServiceConnectionStrings')]"
             },
-            "httpsOnly": true
+            "httpsOnly": "[variables('appServiceHttpsOnly')]"
           },
           "dependsOn": [
             "[parameters('appServiceName')]"

--- a/templates/app-service-linux.json
+++ b/templates/app-service-linux.json
@@ -69,7 +69,7 @@
   },
   "resources": [
     {
-      "condition": "[equals(parameters('deploymentUsingSlots'), false)]",
+      "condition": "[not(parameters('deploymentUsingSlots'))]",
       "apiVersion": "2016-08-01",
       "name": "[parameters('appServiceName')]",
       "type": "Microsoft.Web/sites",
@@ -88,7 +88,7 @@
       }
     },
     {
-      "condition": "[equals(parameters('deploymentUsingSlots'), true)]",
+      "condition": "[parameters('deploymentUsingSlots')]",
       "type": "Microsoft.Web/sites",
       "name": "[parameters('appServiceName')]",
       "kind": "app,linux,container",

--- a/templates/app-service-linux.json
+++ b/templates/app-service-linux.json
@@ -55,29 +55,7 @@
   },
   "variables": {
     "appServicePlanId": "[resourceId(parameters('appServicePlanResourceGroup'), 'Microsoft.Web/serverfarms', parameters('appServicePlanName'))]",
-    "useCustomHostname": "[greater(length(parameters('customHostname')), 0)]",
-    "resources": [
-      {
-        "name": "staging",
-        "type": "slots",
-        "apiVersion": "2016-08-01",
-        "location": "[resourceGroup().location]",
-        "properties": {
-          "clientAffinityEnabled": false,
-          "serverFarmId": "[variables('appServicePlanId')]",
-          "siteConfig": {
-            "alwaysOn": false,
-            "linuxFxVersion": "[parameters('runtimeStack')]",
-            "appSettings": "[parameters('appServiceAppSettings')]",
-            "connectionStrings": "[parameters('appServiceConnectionStrings')]"
-          },
-          "httpsOnly": true
-        },
-        "dependsOn": [
-          "[parameters('appServiceName')]"
-        ]
-      }
-    ]
+    "useCustomHostname": "[greater(length(parameters('customHostname')), 0)]"
   },
   "resources": [
     {
@@ -116,7 +94,7 @@
         "httpsOnly": true
       },
       "dependsOn": [
-        "[parameters('appServiceName')]"
+        "[resourceId('Microsoft.Web/sites', parameters('appServiceName'))]"
       ]
     },
     {

--- a/templates/app-service-linux.json
+++ b/templates/app-service-linux.json
@@ -81,7 +81,7 @@
         "clientAffinityEnabled": "[variables('appServiceClientAffinityEnabled')]",
         "siteConfig": {
           "alwaysOn": "[parameters('webappAlwaysOn')]",
-          "linuxFxVersion": "[variables('appServiceRuntimeStack')]",
+          "linuxFxVersion": "[parameters('runtimeStack')]",
           "appSettings": "[parameters('appServiceAppSettings')]",
           "connectionStrings": "[parameters('appServiceConnectionStrings')]"
         }

--- a/templates/app-service-linux.json
+++ b/templates/app-service-linux.json
@@ -65,11 +65,12 @@
     "appServicePlanId": "[resourceId(parameters('appServicePlanResourceGroup'), 'Microsoft.Web/serverfarms', parameters('appServicePlanName'))]",
     "useCustomHostname": "[greater(length(parameters('customHostname')), 0)]",
     "appServiceHttpsOnly": true,
-    "appServiceClientAffinityEnabled": false
+    "appServiceClientAffinityEnabled": false,
+    "appServiceName": "[concat(parameters('appServiceName'), '-', if(parameters('deploymentUsingSlots'), 'withslots', 'withoutslots'))]"
   },
   "resources": [
     {
-      "name":"[Concat(parameters('appServiceName'),'-1')]",
+      "name":"[variables('appServiceName')]",
       "condition": "[not(parameters('deploymentUsingSlots'))]",
       "apiVersion": "2016-08-01",
       "type": "Microsoft.Web/sites",
@@ -88,7 +89,7 @@
       }
     },
     {
-      "name":"[Concat(parameters('appServiceName'),'-2')]",
+      "name":"[variables('appServiceName')]",
       "condition": "[parameters('deploymentUsingSlots')]",
       "type": "Microsoft.Web/sites",
       "kind": "app,linux,container",
@@ -122,7 +123,7 @@
             "httpsOnly": "[variables('appServiceHttpsOnly')]"
           },
           "dependsOn": [
-            "[parameters('appServiceName')]"
+            "[variables('appServiceName')]"
           ]
         }
       ]
@@ -130,7 +131,7 @@
     {
       "type": "Microsoft.Web/sites/hostnameBindings",
       "condition": "[variables('useCustomHostname')]",
-      "name": "[concat(parameters('appServiceName'), '/', if(variables('useCustomHostname'), parameters('customHostname'), 'placeholder'))]",
+      "name": "[concat(variables('appServiceName'), '/', if(variables('useCustomHostname'), parameters('customHostname'), 'placeholder'))]",
       "apiVersion": "2016-08-01",
       "location": "[resourceGroup().location]",
       "properties": {
@@ -138,14 +139,14 @@
         "thumbprint": "[parameters('certificateThumbprint')]"
       },
       "dependsOn": [
-        "[resourceId('Microsoft.Web/sites', parameters('appServiceName'))]"
+        "[resourceId('Microsoft.Web/sites', variables('appServiceName'))]"
       ]
     }
   ],
   "outputs": {
     "possibleOutboundIpAddresses": {
       "type": "array",
-      "value": "[split(reference(parameters('appServiceName')).possibleOutboundIpAddresses, ',')]"
+      "value": "[split(reference(variables('appServiceName')).possibleOutboundIpAddresses, ',')]"
     }
   }
 }

--- a/templates/app-service-linux.json
+++ b/templates/app-service-linux.json
@@ -51,87 +51,58 @@
       "metadata": {
         "description": "Conditional use of slots when deploying webapp"
       }
-    },
-    "webappAlwaysOn": {
-      "type": "bool",
-      "defaultValue": true
-    },
-    "webappSlotAlwaysOn": {
-      "type": "bool",
-      "defaultValue": false
     }
   },
   "variables": {
     "appServicePlanId": "[resourceId(parameters('appServicePlanResourceGroup'), 'Microsoft.Web/serverfarms', parameters('appServicePlanName'))]",
     "useCustomHostname": "[greater(length(parameters('customHostname')), 0)]",
-    "appServiceHttpsOnly": true,
-    "appServiceClientAffinityEnabled": false,
-    "appServiceName": "[concat(parameters('appServiceName'), '-', if(parameters('deploymentUsingSlots'), 'withslots', 'withoutslots'))]"
+    "resources": [
+      {
+        "name": "staging",
+        "type": "slots",
+        "apiVersion": "2016-08-01",
+        "location": "[resourceGroup().location]",
+        "properties": {
+          "clientAffinityEnabled": false,
+          "serverFarmId": "[variables('appServicePlanId')]",
+          "siteConfig": {
+            "alwaysOn": false,
+            "linuxFxVersion": "[parameters('runtimeStack')]",
+            "appSettings": "[parameters('appServiceAppSettings')]",
+            "connectionStrings": "[parameters('appServiceConnectionStrings')]"
+          },
+          "httpsOnly": true
+        },
+        "dependsOn": [
+          "[parameters('appServiceName')]"
+        ]
+      }
+    ]
   },
   "resources": [
     {
-      "name":"[variables('appServiceName')]",
-      "condition": "[not(parameters('deploymentUsingSlots'))]",
-      "apiVersion": "2016-08-01",
       "type": "Microsoft.Web/sites",
-      "kind": "app,linux,container",
-      "location": "[resourceGroup().location]",
-      "properties": {
-        "httpsOnly": "[variables('appServiceHttpsOnly')]",
-        "serverFarmId": "[variables('appServicePlanId')]",
-        "clientAffinityEnabled": "[variables('appServiceClientAffinityEnabled')]",
-        "siteConfig": {
-          "alwaysOn": "[parameters('webappAlwaysOn')]",
-          "linuxFxVersion": "[parameters('runtimeStack')]",
-          "appSettings": "[parameters('appServiceAppSettings')]",
-          "connectionStrings": "[parameters('appServiceConnectionStrings')]"
-        }
-      }
-    },
-    {
-      "name":"[variables('appServiceName')]",
-      "condition": "[parameters('deploymentUsingSlots')]",
-      "type": "Microsoft.Web/sites",
+      "name": "[parameters('appServiceName')]",
       "kind": "app,linux,container",
       "apiVersion": "2016-08-01",
       "location": "[resourceGroup().location]",
       "properties": {
-        "clientAffinityEnabled": "[variables('appServiceClientAffinityEnabled')]",
+        "clientAffinityEnabled": false,
         "serverFarmId": "[variables('appServicePlanId')]",
         "siteConfig": {
-          "alwaysOn": "[parameters('webappAlwaysOn')]",
+          "alwaysOn": true,
           "appSettings": "[parameters('appServiceAppSettings')]",
-          "connectionStrings": "[parameters('appServiceConnectionStrings')]"
+          "connectionStrings": "[parameters('appServiceConnectionStrings')]",
+          "linuxFxVersion": "[if(not(parameters('deploymentUsingSlots')), parameters('runtimeStack'), json('null'))]"
         },
-        "httpsOnly": "[variables('appServiceHttpsOnly')]"
+        "httpsOnly": true
       },
-      "resources": [
-        {
-          "name": "staging",
-          "type": "slots",
-          "apiVersion": "2016-08-01",
-          "location": "[resourceGroup().location]",
-          "properties": {
-            "clientAffinityEnabled": "[variables('appServiceClientAffinityEnabled')]",
-            "serverFarmId": "[variables('appServicePlanId')]",
-            "siteConfig": {
-              "alwaysOn": "[parameters('webappSlotAlwaysOn')]",
-              "linuxFxVersion": "[parameters('runtimeStack')]",
-              "appSettings": "[parameters('appServiceAppSettings')]",
-              "connectionStrings": "[parameters('appServiceConnectionStrings')]"
-            },
-            "httpsOnly": "[variables('appServiceHttpsOnly')]"
-          },
-          "dependsOn": [
-            "[variables('appServiceName')]"
-          ]
-        }
-      ]
+      "resources": "[if(parameters('deploymentUsingSlots'), variables('resources'), json('null'))]"
     },
     {
       "type": "Microsoft.Web/sites/hostnameBindings",
       "condition": "[variables('useCustomHostname')]",
-      "name": "[concat(variables('appServiceName'), '/', if(variables('useCustomHostname'), parameters('customHostname'), 'placeholder'))]",
+      "name": "[concat(parameters('appServiceName'), '/', if(variables('useCustomHostname'), parameters('customHostname'), 'placeholder'))]",
       "apiVersion": "2016-08-01",
       "location": "[resourceGroup().location]",
       "properties": {
@@ -139,14 +110,14 @@
         "thumbprint": "[parameters('certificateThumbprint')]"
       },
       "dependsOn": [
-        "[resourceId('Microsoft.Web/sites', variables('appServiceName'))]"
+        "[resourceId('Microsoft.Web/sites', parameters('appServiceName'))]"
       ]
     }
   ],
   "outputs": {
     "possibleOutboundIpAddresses": {
       "type": "array",
-      "value": "[split(reference(variables('appServiceName')).possibleOutboundIpAddresses, ',')]"
+      "value": "[split(reference(parameters('appServiceName')).possibleOutboundIpAddresses, ',')]"
     }
   }
 }

--- a/templates/app-service-linux.json
+++ b/templates/app-service-linux.json
@@ -96,8 +96,28 @@
           "linuxFxVersion": "[if(not(parameters('deploymentUsingSlots')), parameters('runtimeStack'), json('null'))]"
         },
         "httpsOnly": true
+      }
+    },
+    {
+      "name": "staging",
+      "condition": "[parameters('deploymentUsingSlots')]",
+      "type": "Microsoft.Web/sites/slots",
+      "apiVersion": "2016-08-01",
+      "location": "[resourceGroup().location]",
+      "properties": {
+        "clientAffinityEnabled": false,
+        "serverFarmId": "[variables('appServicePlanId')]",
+        "siteConfig": {
+          "alwaysOn": false,
+          "linuxFxVersion": "[parameters('runtimeStack')]",
+          "appSettings": "[parameters('appServiceAppSettings')]",
+          "connectionStrings": "[parameters('appServiceConnectionStrings')]"
+        },
+        "httpsOnly": true
       },
-      "resources": "[if(parameters('deploymentUsingSlots'), variables('resources'), json('null'))]"
+      "dependsOn": [
+        "[parameters('appServiceName')]"
+      ]
     },
     {
       "type": "Microsoft.Web/sites/hostnameBindings",

--- a/templates/app-service-linux.json
+++ b/templates/app-service-linux.json
@@ -71,7 +71,7 @@
     {
       "condition": "[not(parameters('deploymentUsingSlots'))]",
       "apiVersion": "2016-08-01",
-      "name":"[Concat(parameters('appServiceName'),'')]",
+      "name":"[Concat(parameters('appServiceName'),'-1')]",
       "type": "Microsoft.Web/sites",
       "kind": "app,linux,container",
       "location": "[resourceGroup().location]",

--- a/templates/app-service-linux.json
+++ b/templates/app-service-linux.json
@@ -77,7 +77,7 @@
       }
     },
     {
-      "name": "staging",
+      "name": "[concat(parameters('appServiceName'), '/',  'staging')]",
       "condition": "[parameters('deploymentUsingSlots')]",
       "type": "Microsoft.Web/sites/slots",
       "apiVersion": "2016-08-01",

--- a/templates/app-service-linux.json
+++ b/templates/app-service-linux.json
@@ -69,9 +69,9 @@
   },
   "resources": [
     {
+      "name":"[Concat(parameters('appServiceName'),'-1')]",
       "condition": "[not(parameters('deploymentUsingSlots'))]",
       "apiVersion": "2016-08-01",
-      "name":"[Concat(parameters('appServiceName'),'-1')]",
       "type": "Microsoft.Web/sites",
       "kind": "app,linux,container",
       "location": "[resourceGroup().location]",
@@ -88,9 +88,9 @@
       }
     },
     {
+      "name":"[Concat(parameters('appServiceName'),'-2')]",
       "condition": "[parameters('deploymentUsingSlots')]",
       "type": "Microsoft.Web/sites",
-      "name": "[parameters('appServiceName')]",
       "kind": "app,linux,container",
       "apiVersion": "2016-08-01",
       "location": "[resourceGroup().location]",

--- a/templates/app-service-linux.json
+++ b/templates/app-service-linux.json
@@ -71,7 +71,7 @@
     {
       "condition": "[not(parameters('deploymentUsingSlots'))]",
       "apiVersion": "2016-08-01",
-      "name": "[parameters('appServiceName')]",
+      "name":"[Concat(parameters('appServiceName'),'')]",
       "type": "Microsoft.Web/sites",
       "kind": "app,linux,container",
       "location": "[resourceGroup().location]",


### PR DESCRIPTION
### Context
There is a desire to change the linux template to allow use of slots as and when required for worker app  deployments. 


### Changes proposed in this pull request
- Add a new boolean type parameter deploymentUsingSlots with a default value set as true 
- Remove slots deployment outside the properties of web site deployment
- Add condition to only deploy slot if param deploymentUsingSlots is set to false
- Put condition on linuxFxVersion/runtimestack site property to be available on if param deploymentUsingSlots is set to false

### Guidance to review
Deployment of slot is controlled by one parameter
No changes required to existing templates linked to app-service-linux.json 
