### PR TITLE
127 investigate release failures caused by postgres firewall rules

### DIFF
--- a/templates/postgresql-server-firewall-rules.json
+++ b/templates/postgresql-server-firewall-rules.json
@@ -36,7 +36,7 @@
         "count": "[length(parameters('ipAddresses'))]",
         "mode": "serial",
         "name": "firewallRuleCopy",
-        "batchSize": 1
+        "batchSize": 3
       }
     }
   ],

--- a/templates/postgresql-server-firewall-rules.json
+++ b/templates/postgresql-server-firewall-rules.json
@@ -34,8 +34,9 @@
       },
       "copy": {
         "count": "[length(parameters('ipAddresses'))]",
-        "mode": "Parallel",
-        "name": "firewallRuleCopy"
+        "mode": "serial",
+        "name": "firewallRuleCopy",
+        "batchSize": 1
       }
     }
   ],


### PR DESCRIPTION
### Context
On random occasions Azure DevOps release fails whilst adding firewall rules in PostgreSQL server with a conflict error message.

### Remediation
Change CopyIndex iteration mode from parallel to serial
Process firewall rules in batches of 3
