### PR TITLE
Add extra configuration flags to be switched on Linux app services

### DIFF
--- a/templates/app-service-linux.json
+++ b/templates/app-service-linux.json
@@ -58,6 +58,13 @@
       "metadata": {
         "description": "Don't let the app sleep after a period of inactivity"
       }
+    },
+    "httpLoggingEnabled": {
+      "type": "bool",
+      "defaultValue": false,
+      "metadata": {
+        "description": "Enable logging of HTTP calls to the app"
+      }
     }
   },
   "variables": {
@@ -76,6 +83,7 @@
         "serverFarmId": "[variables('appServicePlanId')]",
         "siteConfig": {
           "alwaysOn": "[parameters('appAlwaysOn')]",
+          "httpLoggingEnabled": "[parameters('httpLoggingEnabled')]",
           "appSettings": "[parameters('appServiceAppSettings')]",
           "connectionStrings": "[parameters('appServiceConnectionStrings')]",
           "linuxFxVersion": "[if(not(parameters('deploymentUsingSlots')), parameters('runtimeStack'), json('null'))]"

--- a/templates/app-service-linux.json
+++ b/templates/app-service-linux.json
@@ -51,6 +51,13 @@
       "metadata": {
         "description": "Conditional use of slots when deploying webapp"
       }
+    },
+    "appAlwaysOn": {
+      "type": "bool",
+      "defaultValue": true,
+      "metadata": {
+        "description": "Don't let the app sleep after a period of inactivity"
+      }
     }
   },
   "variables": {
@@ -68,7 +75,7 @@
         "clientAffinityEnabled": false,
         "serverFarmId": "[variables('appServicePlanId')]",
         "siteConfig": {
-          "alwaysOn": true,
+          "alwaysOn": "[parameters('appAlwaysOn')]",
           "appSettings": "[parameters('appServiceAppSettings')]",
           "connectionStrings": "[parameters('appServiceConnectionStrings')]",
           "linuxFxVersion": "[if(not(parameters('deploymentUsingSlots')), parameters('runtimeStack'), json('null'))]"


### PR DESCRIPTION
For Teacher Payments, we have the need to configure the `alwaysOn` and `httpLoggingEnabled` flags. This adds these configurations, with sensible defaults