### PR TITLE
Adds support for appCommandLine parameter

### DIFF
--- a/templates/app-service-linux.json
+++ b/templates/app-service-linux.json
@@ -34,6 +34,13 @@
         "description": "The name of the runtime stack for the container"
       }
     },
+    "customStartupCommand": {
+      "type": "string",
+      "defaultValue": "",
+      "metadata": {
+        "description": "Custom startup command for the container running on the app service"
+      }
+    },
     "customHostName": {
       "type": "string",
       "defaultValue": ""
@@ -71,7 +78,8 @@
           "alwaysOn": true,
           "appSettings": "[parameters('appServiceAppSettings')]",
           "connectionStrings": "[parameters('appServiceConnectionStrings')]",
-          "linuxFxVersion": "[if(not(parameters('deploymentUsingSlots')), parameters('runtimeStack'), json('null'))]"
+          "linuxFxVersion": "[if(not(parameters('deploymentUsingSlots')), parameters('runtimeStack'), json('null'))]",
+          "appCommandLine": "[parameters('customStartupCommand')]"
         },
         "httpsOnly": true
       }

--- a/templates/app-service-linux.json
+++ b/templates/app-service-linux.json
@@ -97,7 +97,8 @@
           "alwaysOn": false,
           "linuxFxVersion": "[parameters('runtimeStack')]",
           "appSettings": "[parameters('appServiceAppSettings')]",
-          "connectionStrings": "[parameters('appServiceConnectionStrings')]"
+          "connectionStrings": "[parameters('appServiceConnectionStrings')]",
+          "appCommandLine": "[parameters('customStartupCommand')]"
         },
         "httpsOnly": true
       },


### PR DESCRIPTION
This PR adds support for the appCommandLine which enables consumers to optionally pass a custom start up command to containers running in an app service.