### PR TITLE
Add virtual network support to ACI

### DIFF
--- a/examples/example-aci-with-networking.json
+++ b/examples/example-aci-with-networking.json
@@ -7,30 +7,6 @@
       "metadata": {
         "description": "Prefix of the resources"
       }
-    },
-    "appServicePlanName": {
-      "type": "string",
-      "metadata": {
-        "description": "The name of the app service plan."
-      }
-    },
-    "trafficManagerProfileName": {
-      "type": "string",
-      "metadata": {
-        "description": "The name of the traffic manager profile."
-      }
-    },
-    "trafficManagerEndpointName": {
-      "type": "string",
-      "metadata": {
-        "description": "The name of the traffic manager endpoint."
-      }
-    },
-    "trafficManagerEndpointPriority": {
-      "type": "int",
-      "metadata": {
-        "description": "The priority of the traffic manger endpoint."
-      }
     }
   },
   "variables": {
@@ -58,18 +34,22 @@
             "value": "[variables('vnetName')]"
           },
           "subnetConfiguration": {
-            "value": {
-              "name": "[variables('subnetName')]",
-              "properties": {
-                "addressPrefix": "[variables('subnetAddressPrefix')]",
-                "delegations": {
-                  "name": "DelegationService",
-                  "properties": {
-                    "serviceName": "Microsoft.ContainerInstance/containerGroups"
-                  }
+            "value": [
+              {
+                "name": "[variables('subnetName')]",
+                "properties": {
+                  "addressPrefix": "[variables('subnetAddressPrefix')]",
+                  "delegations": [
+                    {
+                      "name": "DelegationService",
+                      "properties": {
+                        "serviceName": "Microsoft.ContainerInstance/containerGroups"
+                      }
+                    }
+                  ]
                 }
               }
-            }
+            ]
           }
         }
       }

--- a/examples/example-aci-with-networking.json
+++ b/examples/example-aci-with-networking.json
@@ -1,0 +1,134 @@
+{
+  "$schema": "https://schema.management.azure.com/schemas/2015-01-01/deploymentTemplate.json#",
+  "contentVersion": "1.0.0.0",
+  "parameters": {
+    "servicePrefix": {
+      "type": "string",
+      "metadata": {
+        "description": "Prefix of the resources"
+      }
+    },
+    "appServicePlanName": {
+      "type": "string",
+      "metadata": {
+        "description": "The name of the app service plan."
+      }
+    },
+    "trafficManagerProfileName": {
+      "type": "string",
+      "metadata": {
+        "description": "The name of the traffic manager profile."
+      }
+    },
+    "trafficManagerEndpointName": {
+      "type": "string",
+      "metadata": {
+        "description": "The name of the traffic manager endpoint."
+      }
+    },
+    "trafficManagerEndpointPriority": {
+      "type": "int",
+      "metadata": {
+        "description": "The priority of the traffic manger endpoint."
+      }
+    }
+  },
+  "variables": {
+    "templateBaseUrl": "https://raw.githubusercontent.com/DFE-Digital/bat-platform-building-blocks/aci_vnet_support/templates/",
+    "vnetName": "[concat(parameters('servicePrefix'),'-example-vnet')]",
+    "subnetName": "aci-subnet-1",
+    "subnetAddressPrefix": "10.0.0.0/24",
+    "networkProfileName": "[concat(parameters('servicePrefix'),'-example-profile')]",
+    "containerInstanceName": "[concat(parameters('servicePrefix'),'-example-aci')]",
+    "imageName": "hello-world"
+  },
+  "resources": [
+    {
+      "name": "virtual-network",
+      "type": "Microsoft.Resources/deployments",
+      "apiVersion": "2017-05-10",
+      "properties": {
+        "mode": "Incremental",
+        "templateLink": {
+          "uri": "[concat(variables('templateBaseUrl'), 'virtual-network.json')]",
+          "contentVersion": "1.0.0.0"
+        },
+        "parameters": {
+          "vnetName": {
+            "value": "[variables('vnetName')]"
+          },
+          "subnetConfiguration": {
+            "value": {
+              "name": "[variables('subnetName')]",
+              "properties": {
+                "addressPrefix": "[variables('subnetAddressPrefix')]",
+                "delegations": {
+                  "name": "DelegationService",
+                  "properties": {
+                    "serviceName": "Microsoft.ContainerInstance/containerGroups"
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    {
+      "name": "network-profile",
+      "type": "Microsoft.Resources/deployments",
+      "apiVersion": "2017-05-10",
+      "dependsOn": [
+        "virtual-network"
+      ],
+      "properties": {
+        "mode": "Incremental",
+        "templateLink": {
+          "uri": "[concat(variables('templateBaseUrl'), 'container-instance-network-profile.json')]",
+          "contentVersion": "1.0.0.0"
+        },
+        "parameters": {
+          "vnetName": {
+            "value": "[variables('vnetName')]"
+          },
+          "subnetName": {
+            "value": "[variables('subnetName')]"
+          },
+          "networkProfileName": {
+            "value": "[variables('networkProfileName')]"
+          }
+        }
+      }
+    },
+    {
+      "name": "container-instance",
+      "type": "Microsoft.Resources/deployments",
+      "apiVersion": "2017-05-10",
+      "dependsOn": [
+        "network-profile"
+      ],
+      "properties": {
+        "mode": "Incremental",
+        "templateLink": {
+          "uri": "[concat(variables('templateBaseUrl'), 'container-instances.json')]",
+          "contentVersion": "1.0.0.0"
+        },
+        "parameters": {
+          "containerInstanceName": {
+            "value": "[variables('containerInstanceName')]"
+          },
+          "containerName": {
+            "value": "[variables('containerInstanceName')]"
+          },
+          "imageName": {
+            "value": "[variables('imageName')]"
+          },
+          "networkProfileName": {
+            "value": "[variables('networkProfileName')]"
+          }
+        }
+      }
+    }
+  ],
+  "outputs": {}
+}

--- a/examples/example-aci-with-networking.json
+++ b/examples/example-aci-with-networking.json
@@ -7,6 +7,12 @@
       "metadata": {
         "description": "Prefix of the resources"
       }
+    },
+    "postgresServerName": {
+      "type": "string",
+      "metadata": {
+        "description": "The name of the postgres server to configure"
+      }
     }
   },
   "variables": {
@@ -45,6 +51,11 @@
                       "properties": {
                         "serviceName": "Microsoft.ContainerInstance/containerGroups"
                       }
+                    }
+                  ],
+                  "serviceEndpoints": [
+                    {
+                      "service": "Microsoft.Sql"
                     }
                   ]
                 }
@@ -105,6 +116,31 @@
           },
           "networkProfileName": {
             "value": "[variables('networkProfileName')]"
+          }
+        }
+      }
+    },
+    {
+      "name": "postgres-firewall-rule",
+      "type": "Microsoft.Resources/deployments",
+      "apiVersion": "2017-05-10",
+      "dependsOn": [
+        "container-instance"
+      ],
+      "properties": {
+        "mode": "Incremental",
+        "templateLink": {
+          "uri": "[concat(variables('templateBaseUrl'), 'postgresql-server-firewall-rules.json')]",
+          "contentVersion": "1.0.0.0"
+        },
+        "parameters": {
+          "serverName": {
+            "value": "[parameters('postgresServerName')]"
+          },
+          "subnetResourceIdList": {
+            "value": [
+              "[resourceId('Microsoft.Network/virtualNetworks/subnets', variables('vnetName'), variables('subnetName'))]"
+            ]
           }
         }
       }

--- a/templates/container-instance-network-profile.json
+++ b/templates/container-instance-network-profile.json
@@ -25,7 +25,6 @@
     },
     "vnetName": {
       "type": "string",
-      "defaultValue": "",
       "metadata": {
         "description": "The name of the vNet that the container instance will connect to"
       }

--- a/templates/container-instance-network-profile.json
+++ b/templates/container-instance-network-profile.json
@@ -44,7 +44,6 @@
       "type": "Microsoft.Network/networkProfiles",
       "apiVersion": "2018-07-01",
       "location": "[resourceGroup().location]",
-      "dependsOn": [],
       "properties": {
         "containerNetworkInterfaceConfigurations": [
           {

--- a/templates/container-instance-network-profile.json
+++ b/templates/container-instance-network-profile.json
@@ -1,0 +1,69 @@
+{
+  "$schema": "https://schema.management.azure.com/schemas/2015-01-01/deploymentTemplate.json#",
+  "contentVersion": "1.0.0.0",
+  "parameters": {
+    "networkProfileName": {
+      "type": "string",
+      "defaultValue": "aci-networkProfile",
+      "metadata": {
+        "description": "The name of the network profile"
+      }
+    },
+    "interfaceConfigName": {
+      "type": "string",
+      "defaultValue": "eth0",
+      "metadata": {
+        "description": "The name of the interface config"
+      }
+    },
+    "interfaceIpConfig": {
+      "type": "string",
+      "defaultValue": "ipConfig1",
+      "metadata": {
+        "description": "The name of the ip config for the interface"
+      }
+    },
+    "vnetName": {
+      "type": "string",
+      "defaultValue": "",
+      "metadata": {
+        "description": "The name of the vNet that the container instance will connect to"
+      }
+    },
+    "subnetName": {
+      "type": "string",
+      "defaultValue": "",
+      "metadata": {
+        "description": "The name of the subnet that the container instance will connect to"
+      }
+    }
+  },
+  "resources": [
+    {
+      "name": "[parameters('networkProfileName')]",
+      "type": "Microsoft.Network/networkProfiles",
+      "apiVersion": "2018-07-01",
+      "location": "[resourceGroup().location]",
+      "dependsOn": [],
+      "properties": {
+        "containerNetworkInterfaceConfigurations": [
+          {
+            "name": "[parameters('interfaceConfigName')]",
+            "properties": {
+              "ipConfigurations": [
+                {
+                  "name": "[parameters('interfaceIpConfig')]",
+                  "properties": {
+                    "subnet": {
+                      "id": "[resourceId('Microsoft.Network/virtualNetworks/subnets', parameters('vnetName'), parameters('subnetName'))]"
+                    }
+                  }
+                }
+              ]
+            }
+          }
+        ]
+      }
+    }
+  ]
+}

--- a/templates/container-instance-network-profile.json
+++ b/templates/container-instance-network-profile.json
@@ -31,7 +31,6 @@
     },
     "subnetName": {
       "type": "string",
-      "defaultValue": "",
       "metadata": {
         "description": "The name of the subnet that the container instance will connect to"
       }

--- a/templates/container-instances.json
+++ b/templates/container-instances.json
@@ -68,14 +68,26 @@
       "metadata": {
         "description": "List of environment variables in an array format. Provide a name and value field for each variable and name and securevalue for hidden attributes i.e. secrets and password "
       }
+    },
+    "networkProfileName": {
+      "type": "string",
+      "defaultValue": "",
+      "metadata": {
+        "description": "The name of the network profile that will attach to the container instance"
+      }
+    }
+  },
+  "variables": {
+    "networkProfile": {
+      "Id": "[if(greater(length(parameters('networkProfileName')) ,0), resourceId('Microsoft.Network/networkProfiles', parameters('networkProfileName')), 'placeholder')]"
     }
   },
   "resources": [
     {
-      "location": "[resourceGroup().location]",
       "name": "[parameters('containerInstanceName')]",
       "type": "Microsoft.ContainerInstance/containerGroups",
       "apiVersion": "2018-10-01",
+      "location": "[resourceGroup().location]",
       "properties": {
         "containers": [
           {
@@ -94,8 +106,15 @@
           }
         ],
         "restartPolicy": "[parameters('restartPolicy')]",
-        "osType": "[parameters('osType')]"
+        "osType": "[parameters('osType')]",
+        "networkProfile": "[if(greater(length(parameters('networkProfileName')) ,0), variables('networkProfile'), json('null'))]"
       }
     }
-  ]
+  ],
+  "outputs": {
+    "containerIPv4Address": {
+      "type": "string",
+      "value": "[if(greater(length(parameters('networkProfileName')) ,0), reference(resourceId('Microsoft.ContainerInstance/containerGroups/', parameters('containerInstanceName'))).ipAddress.ip, json('null'))]"
+    }
+  }
 }

--- a/templates/container-instances.json
+++ b/templates/container-instances.json
@@ -22,6 +22,7 @@
     },
     "command": {
       "type": "array",
+      "defaultValue": [],
       "metadata": {
         "description": "The commands to execute within the container instance in exec form. - string"
       }

--- a/templates/container-instances.json
+++ b/templates/container-instances.json
@@ -66,6 +66,7 @@
     },
     "environmentVariables": {
       "type": "array",
+      "defaultValue": [],
       "metadata": {
         "description": "List of environment variables in an array format. Provide a name and value field for each variable and name and securevalue for hidden attributes i.e. secrets and password "
       }

--- a/templates/postgresql-server-firewall-rules.json
+++ b/templates/postgresql-server-firewall-rules.json
@@ -42,7 +42,7 @@
         "endIpAddress": "[parameters('ipAddresses')[copyIndex()]]"
       },
       "copy": {
-        "count": "[length(parameters('ipAddresses'))]",
+        "count": "[if(greater(length(parameters('ipAddresses')), 0), length(parameters('ipAddresses')), 1)]",
         "mode": "Parallel",
         "name": "firewallRuleCopy"
       }

--- a/templates/postgresql-server-firewall-rules.json
+++ b/templates/postgresql-server-firewall-rules.json
@@ -12,7 +12,6 @@
     "ipAddresses": {
       "type": "array",
       "defaultValue": [],
-      "minLength": 1,
       "metadata": {
         "description": "Array of IP addresses to whitelist against a SQL server"
       }

--- a/templates/postgresql-server-firewall-rules.json
+++ b/templates/postgresql-server-firewall-rules.json
@@ -20,12 +20,20 @@
       "metadata": {
         "description": "Name of the server to add firewall rules to"
       }
+    },
+    "subnetResourceIdList": {
+      "type": "array",
+      "defaultValue": [],
+      "metadata": {
+        "description": "A list of subnet resource ids."
+      }
     }
   },
   "variables": {},
   "resources": [
     {
-      "name": "[replace(concat(parameters('serverName'), '/', parameters('firewallRuleNamePrefix'), parameters('ipAddresses')[copyIndex()]), '.', '_')]",
+      "name": "[replace(concat(parameters('serverName'), '/', if(greater(length(parameters('firewallRuleNamePrefix')), 0) , parameters('ipAddresses')[copyIndex()], 'placeholder')), '.', '_')]",
+      "condition": "[greater(length(parameters('ipAddresses')), 0)]",
       "type": "Microsoft.DBforPostgreSQL/servers/firewallRules",
       "apiVersion": "2017-12-01",
       "properties": {
@@ -37,6 +45,20 @@
         "mode": "Parallel",
         "name": "firewallRuleCopy"
       }
+    },
+    {
+      "name": "[replace(concat(parameters('serverName'), '/', if(greater(length(parameters('subnetResourceIdList')), 0) , last(split(parameters('subnetResourceIdList')[copyIndex()], '/')), 'placeholder')), '.', '_')]",
+      "condition": "[greater(length(parameters('subnetResourceIdList')), 0)]",
+      "type": "Microsoft.DBforPostgreSQL/servers/virtualNetworkRules",
+      "apiVersion": "2017-12-01",
+      "properties": {
+        "virtualNetworkSubnetId": "[parameters('subnetResourceIdList')[copyIndex()]]"
+      },
+      "copy":{
+        "count": "[if(greater(length(parameters('subnetResourceIdList')), 0), length(parameters('subnetResourceIdList')), 1)]",
+          "mode": "Parallel",
+          "name": "virtualNetworkRuleCopy"
+        }
     }
   ],
   "outputs": {}

--- a/templates/postgresql-server-firewall-rules.json
+++ b/templates/postgresql-server-firewall-rules.json
@@ -4,12 +4,14 @@
   "parameters": {
     "firewallRuleNamePrefix": {
       "type": "string",
+      "defaultValue": "",
       "metadata": {
         "description": "The prefix for the firewall rule name, it will be appended by the IP address"
       }
     },
     "ipAddresses": {
       "type": "array",
+      "defaultValue": [],
       "minLength": 1,
       "metadata": {
         "description": "Array of IP addresses to whitelist against a SQL server"

--- a/templates/virtual-network.json
+++ b/templates/virtual-network.json
@@ -1,0 +1,43 @@
+{
+  "$schema": "http://schema.management.azure.com/schemas/2015-01-01/deploymentTemplate.json#",
+  "contentVersion": "1.0.0.0",
+  "parameters": {
+    "vnetName": {
+      "type": "string",
+      "metadata": {
+        "description": "The name of the arm vnet"
+      }
+    },
+    "vnetAddressSpaceCIDR": {
+      "type": "string",
+      "defaultValue": "10.0.0.0/16",
+      "metadata": {
+        "description": "CIDR for the address space of the ARM Vnet"
+      }
+    },
+    "subnetConfiguration": {
+      "type": "array",
+      "metadata": {
+        "description": "Array of objects in the following schema: https://docs.microsoft.com/en-us/azure/templates/microsoft.network/2018-11-01/virtualnetworks#Subnet"
+      }
+    }
+  },
+  "variables": {},
+  "resources": [
+    {
+      "type": "Microsoft.Network/virtualNetworks",
+      "name": "[parameters('vnetName')]",
+      "apiVersion": "2018-11-01",
+      "location": "[resourceGroup().location]",
+      "properties": {
+        "addressSpace": {
+          "addressPrefixes": [
+            "[parameters('vnetAddressSpaceCIDR')]"
+          ]
+        },
+        "subnets": "[parameters('subnetConfiguration')]"
+      }
+    }
+  ],
+  "outputs": {}
+}


### PR DESCRIPTION
This PR adds ACI networking support and the ability to whitelist subnets on a posgres server firewall.

**Changes:**
* Updated existing ACI block
* Updated existing postgres server firewall block to handle virtual networks
* Added virtual network block
* Added a network profile block to be used with ACI
* Added an example template that consumes the above blocks

**Example**
The example assumes that all resources are in the same resource group and that a posgres server already exists.

It aims to demonstrate the scenario where there may be a requirement to run an ACI instance that communicates with a postgres server that does not have `allow access to azure services` turned on.

```PowerShell
New-AzResourceGroupDeployment -Name aci-network -ResourceGroupName poc-vnet-integration -TemplateFile .\examples\example-aci-with-networking.json -servicePrefix cg -postgresServerName posgres1
```           