### PR TITLE
Changed FirewallRuleCopy to serial from parallel

### DIFF
--- a/templates/postgresql-server-firewall-rules.json
+++ b/templates/postgresql-server-firewall-rules.json
@@ -43,8 +43,9 @@
       },
       "copy": {
         "count": "[if(greater(length(parameters('ipAddresses')), 0), length(parameters('ipAddresses')), 1)]",
-        "mode": "Parallel",
-        "name": "firewallRuleCopy"
+        "mode": "serial",
+        "name": "firewallRuleCopy",
+        "batchSize": 3
       }
     },
     {


### PR DESCRIPTION
### Context
On random occasions Azure DevOps release fails whilst adding firewall rules in PostgreSQL server with a conflict error message.

### Remediation
Change CopyIndex iteration mode from parallel to serial
Process firewall rules in batches of 3