### PR TITLE
Fix JToken type is not valid. Expected 'String'. Actual 'Null' error

### DIFF
--- a/templates/container-instances.json
+++ b/templates/container-instances.json
@@ -116,7 +116,7 @@
   "outputs": {
     "containerIPv4Address": {
       "type": "string",
-      "value": "[if(greater(length(parameters('networkProfileName')) ,0), reference(resourceId('Microsoft.ContainerInstance/containerGroups/', parameters('containerInstanceName'))).ipAddress.ip, json('null'))]"
+      "value": "[if(greater(length(parameters('networkProfileName')) ,0), reference(resourceId('Microsoft.ContainerInstance/containerGroups/', parameters('containerInstanceName'))).ipAddress.ip, '')]"
     }
   }
 }


### PR DESCRIPTION
### Context:
Getting following error when building ACI without a network profile.
"message":"The template output 'containerIPv4Address' is not valid: Template output JToken type is not valid. Expected 'String'. Actual 'Null'.

### Fix:
Replace json('null') with an empty string  
