### PR TITLE
Allow HTTP clients to connect over http2.0

### DIFF
--- a/templates/app-service-linux.json
+++ b/templates/app-service-linux.json
@@ -59,6 +59,13 @@
         "description": "Conditional use of slots when deploying webapp"
       }
     },
+    "http20Enabled": {
+      "type": "bool",
+      "defaultValue": true,
+      "metadata": {
+        "description": " Configures a web site to allow clients to connect over http2.0"
+      }
+    },
     "appAlwaysOn": {
       "type": "bool",
       "defaultValue": true,
@@ -90,6 +97,7 @@
         "serverFarmId": "[variables('appServicePlanId')]",
         "siteConfig": {
           "alwaysOn": "[parameters('appAlwaysOn')]",
+          "http20Enabled": "[parameters('http20Enabled')]",
           "httpLoggingEnabled": "[parameters('httpLoggingEnabled')]",
           "appSettings": "[parameters('appServiceAppSettings')]",
           "connectionStrings": "[parameters('appServiceConnectionStrings')]",

--- a/templates/app-service-linux.json
+++ b/templates/app-service-linux.json
@@ -97,13 +97,13 @@
         "serverFarmId": "[variables('appServicePlanId')]",
         "siteConfig": {
           "alwaysOn": "[parameters('appAlwaysOn')]",
-          "http20Enabled": "[parameters('http20Enabled')]",
           "httpLoggingEnabled": "[parameters('httpLoggingEnabled')]",
           "appSettings": "[parameters('appServiceAppSettings')]",
           "connectionStrings": "[parameters('appServiceConnectionStrings')]",
           "linuxFxVersion": "[if(not(parameters('deploymentUsingSlots')), parameters('runtimeStack'), json('null'))]",
           "appCommandLine": "[parameters('customStartupCommand')]"
         },
+        "http20Enabled": "[parameters('http20Enabled')]",
         "httpsOnly": true
       }
     },

--- a/templates/app-service-linux.json
+++ b/templates/app-service-linux.json
@@ -61,7 +61,7 @@
     },
     "http20Enabled": {
       "type": "bool",
-      "defaultValue": true,
+      "defaultValue": false,
       "metadata": {
         "description": " Configures a web site to allow clients to connect over http2.0"
       }

--- a/templates/app-service-windows.json
+++ b/templates/app-service-windows.json
@@ -88,9 +88,9 @@
         "clientAffinityEnabled": false,
         "httpsOnly": true,
         "state": "[parameters('appServiceState')]",
+        "http20Enabled": "[parameters('http20Enabled')]",
         "siteConfig": {
           "alwaysOn": true,
-          "http20Enabled": "[parameters('http20Enabled')]",
           "appSettings": "[parameters('appServiceAppSettings')]",
           "connectionStrings": "[parameters('appServiceConnectionStrings')]",
           "virtualApplications": "[parameters('appServiceVirtualApplications')]"

--- a/templates/app-service-windows.json
+++ b/templates/app-service-windows.json
@@ -54,6 +54,13 @@
       "type": "bool",
       "defaultValue": true
     },
+    "http20Enabled": {
+      "type": "bool",
+      "defaultValue": true,
+      "metadata": {
+        "description": " Configures a web site to allow clients to connect over http2.0"
+      }
+    },
     "appServiceVirtualApplications": {
       "type": "array",
       "defaultValue": [
@@ -83,6 +90,7 @@
         "state": "[parameters('appServiceState')]",
         "siteConfig": {
           "alwaysOn": true,
+          "http20Enabled": "[parameters('http20Enabled')]",
           "appSettings": "[parameters('appServiceAppSettings')]",
           "connectionStrings": "[parameters('appServiceConnectionStrings')]",
           "virtualApplications": "[parameters('appServiceVirtualApplications')]"

--- a/templates/app-service-windows.json
+++ b/templates/app-service-windows.json
@@ -56,7 +56,7 @@
     },
     "http20Enabled": {
       "type": "bool",
-      "defaultValue": true,
+      "defaultValue": false,
       "metadata": {
         "description": " Configures a web site to allow clients to connect over http2.0"
       }


### PR DESCRIPTION
### Context 
Configures web sites to allow clients to connect over http2.0

### Guidance to Review
Add parameter `http20Enabled` and site config property to enable to disable http2.0