### PR TITLE
Postgres database backup params

### DIFF
--- a/templates/postgresql-server.json
+++ b/templates/postgresql-server.json
@@ -35,7 +35,7 @@
       "allowedValues": [ "enabled", "disabled" ],
       "defaultValue": "disabled",
       "metadata": {
-	"description": "Used to configure autogrow for database storage. If enabled database storage will automatically be increased by 5GB when the free storage is below the greater of 1GB or 10% of the provisioned storage."
+        "description": "Used to configure autogrow for database storage. If enabled database storage will automatically be increased by 5GB when the free storage is below the greater of 1GB or 10% of the provisioned storage."
       }
     },
     "backupRetentionDays": {
@@ -44,7 +44,7 @@
       "maxValue": 35,
       "defaultValue": 35,
       "metadata": {
-	"description": "Retention period for database backups in days."
+        "description": "Retention period for database backups in days."
       }
     },
     "backupToGRS": {

--- a/templates/postgresql-server.json
+++ b/templates/postgresql-server.json
@@ -52,7 +52,7 @@
       "allowedValues": [ "enabled", "disabled" ],
       "defaultValue": "disabled",
       "metadata": {
-	"description": "Used to configure backups for GRS storage. If disabled LRS storage will be used."
+        "description": "Used to configure backups for GRS storage. If disabled LRS storage will be used."
       }
     }
   },

--- a/templates/postgresql-server.json
+++ b/templates/postgresql-server.json
@@ -29,6 +29,31 @@
     },
     "storageAccountName": {
       "type": "string"
+    },
+    "storageAutoGrow": {
+      "type": "string",
+      "allowedValues": [ "enabled", "disabled" ],
+      "defaultValue": "disabled",
+      "metadata": {
+	"description": "Used to configure autogrow for database storage. If enabled database storage will automatically be increased by 5GB when the free storage is below the greater of 1GB or 10% of the provisioned storage."
+      }
+    },
+    "backupRetentionDays": {
+      "type": "int",
+      "minValue": 7,
+      "maxValue": 35,
+      "defaultValue": 35,
+      "metadata": {
+	"description": "Retention period for database backups in days."
+      }
+    },
+    "backupToGRS": {
+      "type": "string",
+      "allowedValues": [ "enabled", "disabled" ],
+      "defaultValue": "disabled",
+      "metadata": {
+	"description": "Used to configure backups for GRS storage. If disabled LRS storage will be used."
+      }
     }
   },
   "variables": {
@@ -44,8 +69,9 @@
       "properties": {
         "storageProfile": {
           "storageMB": "[parameters('postgresSku').size]",
-          "backupRetentionDays": 35,
-          "geoRedundantBackup": "Disabled"
+          "backupRetentionDays": "[parameters('backupRetentionDays')]",
+          "geoRedundantBackup": "[parameters('backupToGRS')]",
+          "storageAutoGrow": "[parameters('storageAutoGrow')]"
         },
         "version": "9.6",
         "sslEnforcement": "Enabled",


### PR DESCRIPTION
**Context**
The building block for the database server does not currently allow any control over configuration of th backups and the ability to auto-grow the storage of the database. This PR addresses those shortcomings by introducing parameters for those values.

**Changes proposed in this pull request**
Changed only templates/postgres-server.json