### PR TITLE
2356 - Added psql vnet firewall json template

### DIFF
--- a/templates/container-instances.json
+++ b/templates/container-instances.json
@@ -22,8 +22,7 @@
     },
     "command": {
       "type": "array",
-      "defaultValue": [
-      ],
+      "defaultValue": [],
       "metadata": {
         "description": "The commands to execute within the container instance in exec form. - string"
       }
@@ -67,8 +66,7 @@
     },
     "environmentVariables": {
       "type": "array",
-      "defaultValue": [
-      ],
+      "defaultValue": [],
       "metadata": {
         "description": "List of environment variables in an array format. Provide a name and value field for each variable and name and securevalue for hidden attributes i.e. secrets and password "
       }

--- a/templates/container-instances.json
+++ b/templates/container-instances.json
@@ -22,7 +22,8 @@
     },
     "command": {
       "type": "array",
-      "defaultValue": [],
+      "defaultValue": [
+      ],
       "metadata": {
         "description": "The commands to execute within the container instance in exec form. - string"
       }
@@ -66,7 +67,8 @@
     },
     "environmentVariables": {
       "type": "array",
-      "defaultValue": [],
+      "defaultValue": [
+      ],
       "metadata": {
         "description": "List of environment variables in an array format. Provide a name and value field for each variable and name and securevalue for hidden attributes i.e. secrets and password "
       }
@@ -77,11 +79,18 @@
       "metadata": {
         "description": "The name of the network profile that will attach to the container instance"
       }
+    },
+    "networkResourceGroup": {
+      "type": "string",
+      "defaultValue": "[resourceGroup().name]",
+      "metadata": {
+        "description": "Name of the resource group if different from the container instance"
+      }
     }
   },
   "variables": {
     "networkProfile": {
-      "Id": "[if(greater(length(parameters('networkProfileName')) ,0), resourceId('Microsoft.Network/networkProfiles', parameters('networkProfileName')), 'placeholder')]"
+      "Id": "[if(greater(length(parameters('networkProfileName')) ,0), resourceId(parameters('networkResourceGroup'),'Microsoft.Network/networkProfiles', parameters('networkProfileName')), 'placeholder')]"
     }
   },
   "resources": [

--- a/templates/postgresql-network-server-firewall-rules.json
+++ b/templates/postgresql-network-server-firewall-rules.json
@@ -1,0 +1,37 @@
+{
+  "$schema": "https://schema.management.azure.com/schemas/2015-01-01/deploymentTemplate.json#",
+  "contentVersion": "1.0.0.0",
+  "parameters": {
+    "serverName": {
+      "type": "string",
+      "metadata": {
+        "description": "Name of the server to add firewall rules to"
+      }
+    },
+    "subnetResourceIdList": {
+      "type": "array",
+      "defaultValue": [],
+      "metadata": {
+        "description": "A list of subnet resource ids."
+      }
+    }
+  },
+  "variables": {},
+  "resources": [
+    {
+      "name": "[replace(concat(parameters('serverName'), '/', if(greater(length(parameters('subnetResourceIdList')), 0) , last(split(parameters('subnetResourceIdList')[copyIndex()], '/')), 'placeholder')), '.', '_')]",
+      "condition": "[greater(length(parameters('subnetResourceIdList')), 0)]",
+      "type": "Microsoft.DBforPostgreSQL/servers/virtualNetworkRules",
+      "apiVersion": "2017-12-01",
+      "properties": {
+        "virtualNetworkSubnetId": "[parameters('subnetResourceIdList')[copyIndex()]]"
+      },
+      "copy":{
+        "count": "[if(greater(length(parameters('subnetResourceIdList')), 0), length(parameters('subnetResourceIdList')), 1)]",
+          "mode": "Parallel",
+          "name": "virtualNetworkRuleCopy"
+        }
+    }
+  ],
+  "outputs": {}
+}


### PR DESCRIPTION
### Context
- Create a new psql server firewall rules template (for vnets) from an existing json because of a bug. 
- In CIP, resource group for vNETs are different from container instance resource groups. Add a vnet resource group parameter to CI template.

### Guidance
A bug in ARM templates doesn't allow vnet firewall changes in psql because the batch size in copy function (line 48 in`template https://github.com/DFE-Digital/bat-platform-building-blocks/blob/master/templates/postgresql-server-firewall-rules.json` is greater than number of default (null) value of parameter ipAddresses)
```The count can't be a negative number. If you deploy a template with Azure PowerShell 2.6 or later, Azure CLI 2.0.74 or later, or REST API version 2019-05-10 or later, you can set count to zero. Earlier versions of PowerShell, CLI, and the REST API don't support zero for count.```