### PR TITLE
Conditional URL availability monitoring

### DIFF
--- a/examples/example-linked-template.json
+++ b/examples/example-linked-template.json
@@ -34,7 +34,14 @@
     }
   },
   "variables": {
-    "templateBaseUrl": "https://raw.githubusercontent.com/DFE-Digital/bat-platform-building-blocks/master/templates/"
+    "templateBaseUrl": "https://raw.githubusercontent.com/DFE-Digital/bat-platform-building-blocks/master/templates/",
+    "availabilityTests": [
+      {
+        "nameSuffix": "root",
+        "url": "[concat('https://', parameters('appServiceName'), '.azurewebsites.net')]",
+        "guid": "[guid(parameters('appServiceName')]"
+      }
+    ]
   },
   "resources": [
     {
@@ -107,6 +114,9 @@
           },
           "attachedService": {
             "value": "[parameters('appServiceName')]"
+          },
+          "availabilityTests": {
+            "value": "[variables('availabilityTests')]"
           }
         }
       }

--- a/templates/application-insights.json
+++ b/templates/application-insights.json
@@ -11,6 +11,13 @@
     "attachedService": {
       "defaultValue": "",
       "type": "string"
+    },
+    "availabilityTests": {
+      "defaultValue": [],
+      "type": "array",
+      "metadata": {
+        "description": "Array of test objects to configure URLs to perform availability tests for."
+      }
     }
   },
   "resources": [
@@ -26,6 +33,46 @@
       "properties": {
         "Application_Type": "web"
       }
+    },
+    {
+      "apiVersion": "2015-05-01",
+      "name": "[concat(parameters('appInsightsName'), '-at-', parameters('availabilityTests')[copyIndex('webTestsCopy')].nameSuffix)]",
+      "type": "Microsoft.Insights/webtests",
+      "condition": "[greater(length(parameters('availabilityTests')), 0)]",
+      "location": "[resourceGroup().location]",
+      "copy": {
+        "name": "webTestsCopy",
+        "count": "[if(greater(length(parameters('availabilityTests')), 0), length(parameters('availabilityTests')), 1)]"
+      },
+      "tags": {
+        "[concat('hidden-link:', resourceId('Microsoft.Insights/components', parameters('appInsightsName')))]": "Resource"
+      },
+      "properties": {
+        "SyntheticMonitorId": "[concat(parameters('appInsightsName'), '-at-', parameters('availabilityTests')[copyIndex('webTestsCopy')].nameSuffix)]",
+        "Name": "[concat(parameters('appInsightsName'), '-at-', parameters('availabilityTests')[copyIndex('webTestsCopy')].nameSuffix)]",
+        "Enabled": true,
+        "Frequency": 300,
+        "Timeout": 120,
+        "RetryEnabled": true,
+        "Locations": [
+          {
+            "Id": "emea-se-sto-edge"
+          },
+          {
+            "Id": "emea-ru-msa-edge"
+          },
+          {
+            "Id": "emea-gb-db3-azr"
+          }
+        ],
+        "Kind": "ping",
+        "Configuration": {
+          "WebTest": "[concat('<WebTest Name=\"', parameters('appInsightsName'), '-at-', parameters('availabilityTests')[copyIndex('webTestsCopy')].nameSuffix, '\"',  ' Id=\"', parameters('availabilityTests')[copyIndex('webTestsCopy')].guid,'\"    Enabled=\"True\" CssProjectStructure=\"\" CssIteration=\"\" Timeout=\"0\" WorkItemIds=\"\" xmlns=\"http://microsoft.com/schemas/VisualStudio/TeamTest/2010\" Description=\"\" CredentialUserName=\"\" CredentialPassword=\"\" PreAuthenticate=\"True\" Proxy=\"default\" StopOnError=\"False\" RecordedResultFile=\"\" ResultsLocale=\"\">        <Items>        <Request Method=\"GET\" Guid=\"a5f10126-e4cd-570d-961c-cea43999a200\" Version=\"1.1\" Url=\"', replace(parameters('availabilityTests')[copyIndex('webTestsCopy')].url, '&', '&amp;'),'\" ThinkTime=\"0\" Timeout=\"300\" ParseDependentRequests=\"True\" FollowRedirects=\"True\" RecordResult=\"True\" Cache=\"False\" ResponseTimeGoal=\"0\" Encoding=\"utf-8\" ExpectedHttpStatusCode=\"200\" ExpectedResponseUrl=\"\" ReportingName=\"\" IgnoreHttpStatusCode=\"False\" /></Items></WebTest>')]"
+	}
+      },
+      "dependsOn": [
+        "[resourceId('Microsoft.Insights/components', parameters('appInsightsName'))]"
+      ]
     }
   ],
   "outputs": {


### PR DESCRIPTION
This PR adds a conditional feature to the app insights template to enable availability monitoring for webapp URLs.

The template has an added `availabilityTest` array parameter which if populated will trigger the webtests to be created. The `availabiltyTests` array must be populated with the following object configuration, one per URL to be tested.
```
{
  "nameSuffix": "<A suffix to be added to the availability test name for identification>",
  "url": "<The full URL to availability test>",
  "guid": "[guid('<String to generate GUID from, e.g. The URL>')]"
}
```

The examples have been updated to show how this is used in the real world.

The availability tests use the default configuration of ping testing the URL and expects to 200 OK to be returned to signify success. The tests are configured to run every five minutes with a two minute timeout.

This change only covers the monitoring aspects, the alerting aspects of availability monitoring are still in development and will follow in a future PR.