### PR TITLE
Availability test fix

### DIFF
--- a/templates/availability-tests.json
+++ b/templates/availability-tests.json
@@ -52,10 +52,7 @@
         "Configuration": {
           "WebTest": "[concat('<WebTest Name=\"', parameters('appInsightsName'), '-at-', parameters('availabilityTests')[copyIndex('webTestsCopy')].nameSuffix, '\"',  ' Id=\"', parameters('availabilityTests')[copyIndex('webTestsCopy')].guid,'\"    Enabled=\"True\" CssProjectStructure=\"\" CssIteration=\"\" Timeout=\"0\" WorkItemIds=\"\" xmlns=\"http://microsoft.com/schemas/VisualStudio/TeamTest/2010\" Description=\"\" CredentialUserName=\"\" CredentialPassword=\"\" PreAuthenticate=\"True\" Proxy=\"default\" StopOnError=\"False\" RecordedResultFile=\"\" ResultsLocale=\"\">        <Items>        <Request Method=\"GET\" Guid=\"a5f10126-e4cd-570d-961c-cea43999a200\" Version=\"1.1\" Url=\"', replace(parameters('availabilityTests')[copyIndex('webTestsCopy')].url, '&', '&amp;'),'\" ThinkTime=\"0\" Timeout=\"300\" ParseDependentRequests=\"True\" FollowRedirects=\"True\" RecordResult=\"True\" Cache=\"False\" ResponseTimeGoal=\"0\" Encoding=\"utf-8\" ExpectedHttpStatusCode=\"200\" ExpectedResponseUrl=\"\" ReportingName=\"\" IgnoreHttpStatusCode=\"False\" /></Items></WebTest>')]"
 	}
-      },
-      "dependsOn": [
-        "[resourceId('Microsoft.Insights/components', parameters('appInsightsName'))]"
-      ]
+      }
     }
   ]
 }

--- a/templates/availability-tests.json
+++ b/templates/availability-tests.json
@@ -1,0 +1,61 @@
+{
+  "$schema": "https://schema.management.azure.com/schemas/2015-01-01/deploymentTemplate.json#",
+  "contentVersion": "1.0.0.0",
+  "parameters": {
+    "appInsightsName": {
+      "type": "string",
+      "metadata": {
+        "description": "Name of the application insights resource"
+      }
+    },
+    "availabilityTests": {
+      "defaultValue": [],
+      "type": "array",
+      "metadata": {
+        "description": "Array of test objects to configure URLs to perform availability tests for."
+      }
+    }
+  },
+  "resources": [
+    {
+      "apiVersion": "2015-05-01",
+      "name": "[if(greater(length(parameters('availabilityTests')), 0), concat(parameters('appInsightsName'), '-at-', parameters('availabilityTests')[copyIndex('webTestsCopy')].nameSuffix), 'UNUSED_WEBTEST')]",
+      "type": "Microsoft.Insights/webtests",
+      "condition": "[greater(length(parameters('availabilityTests')), 0)]",
+      "location": "[resourceGroup().location]",
+      "copy": {
+        "name": "webTestsCopy",
+        "count": "[if(greater(length(parameters('availabilityTests')), 0), length(parameters('availabilityTests')), 1)]"
+      },
+      "tags": {
+        "[concat('hidden-link:', resourceId('Microsoft.Insights/components', parameters('appInsightsName')))]": "Resource"
+      },
+      "properties": {
+        "SyntheticMonitorId": "[concat(parameters('appInsightsName'), '-at-', parameters('availabilityTests')[copyIndex('webTestsCopy')].nameSuffix)]",
+        "Name": "[concat(parameters('appInsightsName'), '-at-', parameters('availabilityTests')[copyIndex('webTestsCopy')].nameSuffix)]",
+        "Enabled": true,
+        "Frequency": 300,
+        "Timeout": 120,
+        "RetryEnabled": true,
+        "Locations": [
+          {
+            "Id": "emea-se-sto-edge"
+          },
+          {
+            "Id": "emea-ru-msa-edge"
+          },
+          {
+            "Id": "emea-gb-db3-azr"
+          }
+        ],
+        "Kind": "ping",
+        "Configuration": {
+          "WebTest": "[concat('<WebTest Name=\"', parameters('appInsightsName'), '-at-', parameters('availabilityTests')[copyIndex('webTestsCopy')].nameSuffix, '\"',  ' Id=\"', parameters('availabilityTests')[copyIndex('webTestsCopy')].guid,'\"    Enabled=\"True\" CssProjectStructure=\"\" CssIteration=\"\" Timeout=\"0\" WorkItemIds=\"\" xmlns=\"http://microsoft.com/schemas/VisualStudio/TeamTest/2010\" Description=\"\" CredentialUserName=\"\" CredentialPassword=\"\" PreAuthenticate=\"True\" Proxy=\"default\" StopOnError=\"False\" RecordedResultFile=\"\" ResultsLocale=\"\">        <Items>        <Request Method=\"GET\" Guid=\"a5f10126-e4cd-570d-961c-cea43999a200\" Version=\"1.1\" Url=\"', replace(parameters('availabilityTests')[copyIndex('webTestsCopy')].url, '&', '&amp;'),'\" ThinkTime=\"0\" Timeout=\"300\" ParseDependentRequests=\"True\" FollowRedirects=\"True\" RecordResult=\"True\" Cache=\"False\" ResponseTimeGoal=\"0\" Encoding=\"utf-8\" ExpectedHttpStatusCode=\"200\" ExpectedResponseUrl=\"\" ReportingName=\"\" IgnoreHttpStatusCode=\"False\" /></Items></WebTest>')]"
+	}
+      },
+      "dependsOn": [
+        "[resourceId('Microsoft.Insights/components', parameters('appInsightsName'))]"
+      ]
+    }
+  ]
+}


### PR DESCRIPTION
This PR is phase one of two. A use case has been identified where a circular dependency can be created in the application insights building block when the availability tests are enabled.

This PR separates the availability tests out into its own template. Going forwards the dependency between the application insights and availability tests templates will have to be managed manually by the user in the parent template.

The original functionality of the availability tests will remain in the insights templates for the time being because removal of this would break the apply service. Apply will be migrated in due course at which point the duplication of code can be removed.