### PR TITLE
Revised app service plan to support PremiumV2 tier

### DIFF
--- a/templates/app-service-plan.json
+++ b/templates/app-service-plan.json
@@ -13,7 +13,8 @@
       "allowedValues": [
         "Basic",
         "Standard",
-        "Premium"
+        "Premium",
+        "PremiumV2"
       ],
       "defaultValue": "Standard",
       "metadata": {
@@ -45,7 +46,9 @@
       }
     }
   },
-  "variables": {},
+  "variables": {
+    "v2Suffix": "[if(equals(parameters('appServicePlanTier'),'PremiumV2'), 'v2', '')]"
+  },
   "resources": [
     {
       "type": "Microsoft.Web/serverfarms",
@@ -53,10 +56,10 @@
       "apiVersion": "2016-09-01",
       "location": "[resourceGroup().location]",
       "sku": {
-        "name": "[concat(take(parameters('appServicePlanTier'), 1), parameters('appServicePlanSize'))]",
+        "name": "[concat(take(parameters('appServicePlanTier'), 1), parameters('appServicePlanSize'), variables('v2Suffix'))]",
         "tier": "[parameters('appServicePlanTier')]",
-        "size": "[concat(take(parameters('appServicePlanTier'), 1), parameters('appServicePlanSize'))]",
-        "family": "[take(parameters('appServicePlanTier'), 1)]",
+        "size": "[concat(take(parameters('appServicePlanTier'), 1), parameters('appServicePlanSize'), variables('v2Suffix'))]",
+        "family": "[concat(take(parameters('appServicePlanTier'), 1), variables('v2Suffix'))]",
         "capacity": "[parameters('appServicePlanInstances')]"
       },
       "kind": "[parameters('appServicePlanOS')]",


### PR DESCRIPTION
The current app-service-plan building block code cannot handle the use of the PremiumV2 tier. The changes in this PR enable to use of the PremiumV2 tier while maintaining backwards compatibility of the existing tiers in existing dependant services.