### PR TITLE
Added action group and availability test alert templates

### DIFF
--- a/examples/example-linked-template.json
+++ b/examples/example-linked-template.json
@@ -31,6 +31,18 @@
       "metadata": {
         "description": "The priority of the traffic manger endpoint."
       }
+    },
+    "alertEmailRecipientName": {
+      "type": "string",
+      "metadata": {
+        "description": "The name of the alert email recipient."
+      }
+    },
+    "alertEmailRecipientAddress": {
+      "type": "string",
+      "metadata": {
+        "description": "The email address of the alert email recipient."
+      }
     }
   },
   "variables": {
@@ -40,6 +52,12 @@
         "nameSuffix": "root",
         "url": "[concat('https://', parameters('appServiceName'), '.azurewebsites.net')]",
         "guid": "[guid(parameters('appServiceName')]"
+      }
+    ],
+    "alertRecipientEmails": [
+      {
+        "displayName": "[parameters('alertEmailRecipientName')]",
+        "emailAddress": "[parameters('alertEmailRecipientAddress')]"
       }
     ]
   },
@@ -114,12 +132,91 @@
           },
           "attachedService": {
             "value": "[parameters('appServiceName')]"
+          }
+        }
+      }
+    },
+    {
+      "apiVersion": "2017-05-10",
+      "name": "availability-test",
+      "type": "Microsoft.Resources/deployments",
+      "properties": {
+        "mode": "Incremental",
+        "templateLink": {
+          "uri": "[concat(variables('templateBaseUrl'), 'availability-tests.json')]",
+          "contentVersion": "1.0.0.0"
+        },
+        "parameters": {
+          "appInsightsName": {
+            "value": "[parameters('appServiceName')]"
           },
           "availabilityTests": {
             "value": "[variables('availabilityTests')]"
           }
         }
-      }
+      },
+      "dependsOn": [
+        "app-insights"
+      ]
+    },
+    {
+      "apiVersion": "2017-05-10",
+      "name": "action-group",
+      "type": "Microsoft.Resources/deployments",
+      "properties": {
+        "mode": "Incremental",
+        "templateLink": {
+          "uri": "[concat(variables('templateBaseUrl'), 'action-group.json')]",
+          "contentVersion": "1.0.0.0"
+        },
+        "parameters": {
+          "appInsightsName": {
+            "value": "[parameters('appServiceName')]"
+          },
+          "alertRecipientEmails": {
+            "value": "[variables('alertRecipientEmails')]"
+          }
+        }
+      },
+      "dependsOn": [
+        "app-insights"
+      ]
+    },
+    {
+      "apiVersion": "2017-05-10",
+      "name": "availability-test-alert",
+      "type": "Microsoft.Resources/deployments",
+      "properties": {
+        "mode": "Incremental",
+        "templateLink": {
+          "uri": "[concat(variables('templateBaseUrl'), 'availability-test-alert.json')]",
+          "contentVersion": "1.0.0.0"
+        },
+        "parameters": {
+          "appInsightsName": {
+            "value": "[parameters('appServiceName')]"
+          },
+          "appInsightsId": {
+            "value": "[reference('app-insights').outputs.AppInsightsResourceId.value]"
+          },
+          "alertName": {
+            "value": "site-root"
+          },
+          "actionGroupId": {
+            "value": "[reference('action-group', '2019-03-01').outputs.actionGroupResourceId.value]"
+          },
+          "alertDescriptionText": {
+            "value": "The site root test failed."
+          },
+          "webTestId": {
+            "value": "[resourceId('microsoft.insights/webtests', concat(parameters('appServiceName'), '-at-', variables('availabilityTests').nameSuffix))]"
+          }
+        }
+      },
+      "dependsOn": [
+        "action-group",
+        "availability-test"
+      ]
     },
     {
       "name": "traffic-manager-profile",

--- a/templates/action-group.json
+++ b/templates/action-group.json
@@ -1,0 +1,62 @@
+{
+  "$schema": "https://schema.management.azure.com/schemas/2015-01-01/deploymentTemplate.json#",
+  "contentVersion": "1.0.0.0",
+  "parameters": {
+    "appInsightsName": {
+      "type": "string",
+      "metadata": {
+        "description": "Name of the application insights resource"
+      }
+    },
+    "alertRecipientEmails": {
+      "defaultValue": [],
+      "type": "array",
+      "metadata": {
+        "description": "Array of email recipient objects to send alerts to. Each email recipient objectsshould have the variables 'displayName' and 'emailAddress'."
+      }
+    }
+  },
+  "variables": {
+    "actionGroupName": "[concat(parameters('appInsightsName'), '-ag-operations')]",
+    "actionGroupShortName": "[concat(split(parameters('appInsightsName'), '-')[0], '-ops')]"
+  },
+  "resources": [
+    {
+      "apiVersion": "2019-03-01",
+      "type": "microsoft.insights/actionGroups",
+      "name": "[variables('actionGroupName')]",
+      "condition": "[greater(length(parameters('alertRecipientEmails')), 0)]",
+      "location": "global",
+      "tags": {},
+      "properties": {
+        "groupShortName": "[variables('actionGroupShortName')]",
+        "enabled": true,
+        "copy": [
+          {
+            "name": "emailReceivers",
+            "count": "[if(greater(length(parameters('alertRecipientEmails')), 0), length(parameters('alertRecipientEmails')), 1)]",
+            "input": {
+                "name": "[parameters('alertRecipientEmails')[copyIndex('emailReceivers')].displayName]",
+                "emailAddress": "[parameters('alertRecipientEmails')[copyIndex('emailReceivers')].emailAddress]",
+                "useCommonAlertSchema": false
+            }
+          }
+        ],
+        "smsReceivers": [],
+        "webhookReceivers": [],
+        "itsmReceivers": [],
+        "azureAppPushReceivers": [],
+        "automationRunbookReceivers": [],
+        "voiceReceivers": [],
+        "logicAppReceivers": [],
+        "azureFunctionReceivers": []
+      }
+    }
+  ],
+  "outputs": {
+    "actionGroupResourceId": {
+      "type": "string",
+      "value": "[resourceId('Microsoft.Insights/actionGroups', variables('actionGroupName'))]"
+    }
+  }
+}

--- a/templates/application-insights.json
+++ b/templates/application-insights.json
@@ -83,6 +83,10 @@
     "AppId": {
       "type": "string",
       "value": "[reference(concat('microsoft.insights/components/', parameters('appInsightsName'))).AppId]"
+    },
+    "AppInsightsResourceId": {
+      "type": "string",
+      "value": "[resourceId('microsoft.insights/components/', parameters('appInsightsName'))]"
     }
   }
 }

--- a/templates/availability-test-alert.json
+++ b/templates/availability-test-alert.json
@@ -1,0 +1,107 @@
+{
+  "$schema": "https://schema.management.azure.com/schemas/2015-01-01/deploymentTemplate.json#",
+  "contentVersion": "1.0.0.0",
+  "parameters": {
+    "appInsightsName": {
+      "type": "string",
+      "metadata": {
+        "description": "Name of the application insights resource."
+      }
+    },
+    "appInsightsId": {
+      "type": "string",
+      "metadata": {
+        "description": "ResourceId for Application Insights resource."
+      }
+    },
+    "alertName": {
+      "type": "string",
+      "metadata": {
+        "description": "Name for the metric alert resource."
+      }
+    },
+    "actionGroupId": {
+      "type": "string",
+      "metadata": {
+        "description": "ResourceID for actionGroup resource."
+      }
+    },
+    "alertDescriptionText": {
+      "defaultValue": "",
+      "type": "string",
+      "metadata": {
+        "description": "Email alert description content to describe the alert cause."
+      }
+    },
+    "alertSeverity": {
+      "defaultValue": 1,
+      "minValue": 0,
+      "maxValue": 4,
+      "type": "int",
+      "metadata": {
+        "description": "Severity of the alert to raise."
+      }
+    },
+    "webTestId": {
+      "type": "string",
+      "metadata": {
+        "decsription": "ResourceId for the availability web test to generate alerts for."
+      }
+    },
+    "evaluationFrequency": {
+      "type": "string",
+      "defaultValue": "PT1M",
+      "metadata": {
+        "decsription": "Frequency with which to monitor the metric data for this alert rule. Default is once a minute."
+      }
+    },
+    "windowSize": {
+      "type": "string",
+      "defaultValue": "PT5M",
+      "metadata": {
+        "decsription": "The time window over which to perform the evaluation of the metric data. Default is 5 minutes."
+      }
+    },
+    "failedLocationCount": {
+      "type": "int",
+      "defaultValue": 1,
+      "metadata": {
+        "decsription": "Number of times the test can fail before an alert is sent."
+      }
+    }
+  },
+  "variables": {
+    "scopes": "[createArray(parameters('appInsightsId'), parameters('webTestId'))]"
+  },
+  "resources": [
+    {
+      "apiVersion": "2018-03-01",
+      "type": "microsoft.insights/metricalerts",
+      "name": "[parameters('alertName')]",
+      "location": "global",
+      "tags": {
+        "[concat('hidden-link:', resourceId('Microsoft.Insights/components', parameters('appInsightsName')))]": "Resource"
+      },
+      "properties": {
+        "description": "[parameters('alertDescriptionText')]",
+        "severity": "[parameters('alertSeverity')]",
+        "enabled": true,
+        "scopes": "[variables('scopes')]",
+        "evaluationFrequency": "[parameters('evaluationFrequency')]",
+        "windowSize": "[parameters('windowSize')]",
+        "criteria": {
+          "odata.type": "Microsoft.Azure.Monitor.WebtestLocationAvailabilityCriteria",
+          "componentId": "[parameters('appInsightsId')]",
+          "webTestId": "[parameters('webTestId')]",
+          "failedLocationCount": "[parameters('failedLocationCount')]"
+        },
+        "actions": [
+          {
+            "actionGroupId": "[parameters('actionGroupId')]",
+            "webHookProperties": {}
+          }
+        ]
+      }
+    }
+  ]
+}

--- a/templates/availability-tests.json
+++ b/templates/availability-tests.json
@@ -12,7 +12,7 @@
       "defaultValue": [],
       "type": "array",
       "metadata": {
-        "description": "Array of test objects to configure URLs to perform availability tests for."
+        "description": "Array of availability test objects to configure URLs to perform availability tests for. Availability test objects must contain the following the variables 'nameSuffix', 'url' and 'guid'."
       }
     }
   },


### PR DESCRIPTION
This PR introduces the following changes:

1. New action group template for sending alert emails.
2. New availability test alert template for linking the existing availability alert templates with the above action group resources.
3. Added an additional output  to the application insights building block.
4. Modified one of the example template to demonstrate these changes in use in a very simple form.