### PR TITLE
Added resource tags to recently added new templates.

### DIFF
--- a/templates/action-group.json
+++ b/templates/action-group.json
@@ -14,6 +14,10 @@
       "metadata": {
         "description": "Array of email recipient objects to send alerts to. Each email recipient objectsshould have the variables 'displayName' and 'emailAddress'."
       }
+    },
+    "resourceTags": {
+      "type": "object",
+      "defaultValue": {}
     }
   },
   "variables": {
@@ -27,7 +31,7 @@
       "name": "[variables('actionGroupName')]",
       "condition": "[greater(length(parameters('alertRecipientEmails')), 0)]",
       "location": "global",
-      "tags": {},
+      "tags": "[parameters('resourceTags')]",
       "properties": {
         "groupShortName": "[variables('actionGroupShortName')]",
         "enabled": true,

--- a/templates/application-insights.json
+++ b/templates/application-insights.json
@@ -12,13 +12,6 @@
       "defaultValue": "",
       "type": "string"
     },
-    "availabilityTests": {
-      "defaultValue": [],
-      "type": "array",
-      "metadata": {
-        "description": "Array of test objects to configure URLs to perform availability tests for."
-      }
-    },
     "resourceTags": {
       "type": "object",
       "defaultValue": {}
@@ -43,44 +36,6 @@
       "properties": {
         "Application_Type": "web"
       }
-    },
-    {
-      "apiVersion": "2015-05-01",
-      "name": "[if(greater(length(parameters('availabilityTests')), 0), concat(parameters('appInsightsName'), '-at-', parameters('availabilityTests')[copyIndex('webTestsCopy')].nameSuffix), 'UNUSED_WEBTEST')]",
-      "type": "Microsoft.Insights/webtests",
-      "condition": "[greater(length(parameters('availabilityTests')), 0)]",
-      "location": "[resourceGroup().location]",
-      "copy": {
-        "name": "webTestsCopy",
-        "count": "[if(greater(length(parameters('availabilityTests')), 0), length(parameters('availabilityTests')), 1)]"
-      },
-      "tags": "[union(variables('componentTag'),parameters('resourceTags'))]",
-      "properties": {
-        "SyntheticMonitorId": "[concat(parameters('appInsightsName'), '-at-', parameters('availabilityTests')[copyIndex('webTestsCopy')].nameSuffix)]",
-        "Name": "[concat(parameters('appInsightsName'), '-at-', parameters('availabilityTests')[copyIndex('webTestsCopy')].nameSuffix)]",
-        "Enabled": true,
-        "Frequency": 300,
-        "Timeout": 120,
-        "RetryEnabled": true,
-        "Locations": [
-          {
-            "Id": "emea-se-sto-edge"
-          },
-          {
-            "Id": "emea-ru-msa-edge"
-          },
-          {
-            "Id": "emea-gb-db3-azr"
-          }
-        ],
-        "Kind": "ping",
-        "Configuration": {
-          "WebTest": "[concat('<WebTest Name=\"', parameters('appInsightsName'), '-at-', parameters('availabilityTests')[copyIndex('webTestsCopy')].nameSuffix, '\"',  ' Id=\"', parameters('availabilityTests')[copyIndex('webTestsCopy')].guid,'\"    Enabled=\"True\" CssProjectStructure=\"\" CssIteration=\"\" Timeout=\"0\" WorkItemIds=\"\" xmlns=\"http://microsoft.com/schemas/VisualStudio/TeamTest/2010\" Description=\"\" CredentialUserName=\"\" CredentialPassword=\"\" PreAuthenticate=\"True\" Proxy=\"default\" StopOnError=\"False\" RecordedResultFile=\"\" ResultsLocale=\"\">        <Items>        <Request Method=\"GET\" Guid=\"a5f10126-e4cd-570d-961c-cea43999a200\" Version=\"1.1\" Url=\"', replace(parameters('availabilityTests')[copyIndex('webTestsCopy')].url, '&', '&amp;'),'\" ThinkTime=\"0\" Timeout=\"300\" ParseDependentRequests=\"True\" FollowRedirects=\"True\" RecordResult=\"True\" Cache=\"False\" ResponseTimeGoal=\"0\" Encoding=\"utf-8\" ExpectedHttpStatusCode=\"200\" ExpectedResponseUrl=\"\" ReportingName=\"\" IgnoreHttpStatusCode=\"False\" /></Items></WebTest>')]"
-	}
-      },
-      "dependsOn": [
-        "[resourceId('Microsoft.Insights/components', parameters('appInsightsName'))]"
-      ]
     }
   ],
   "outputs": {

--- a/templates/application-insights.json
+++ b/templates/application-insights.json
@@ -12,6 +12,13 @@
       "defaultValue": "",
       "type": "string"
     },
+    "availabilityTests": {
+      "defaultValue": [],
+      "type": "array",
+      "metadata": {
+        "description": "Array of test objects to configure URLs to perform availability tests for."
+      }
+    },
     "resourceTags": {
       "type": "object",
       "defaultValue": {}
@@ -36,6 +43,44 @@
       "properties": {
         "Application_Type": "web"
       }
+    },
+    {
+      "apiVersion": "2015-05-01",
+      "name": "[if(greater(length(parameters('availabilityTests')), 0), concat(parameters('appInsightsName'), '-at-', parameters('availabilityTests')[copyIndex('webTestsCopy')].nameSuffix), 'UNUSED_WEBTEST')]",
+      "type": "Microsoft.Insights/webtests",
+      "condition": "[greater(length(parameters('availabilityTests')), 0)]",
+      "location": "[resourceGroup().location]",
+      "copy": {
+        "name": "webTestsCopy",
+        "count": "[if(greater(length(parameters('availabilityTests')), 0), length(parameters('availabilityTests')), 1)]"
+      },
+      "tags": "[union(variables('componentTag'),parameters('resourceTags'))]",
+      "properties": {
+        "SyntheticMonitorId": "[concat(parameters('appInsightsName'), '-at-', parameters('availabilityTests')[copyIndex('webTestsCopy')].nameSuffix)]",
+        "Name": "[concat(parameters('appInsightsName'), '-at-', parameters('availabilityTests')[copyIndex('webTestsCopy')].nameSuffix)]",
+        "Enabled": true,
+        "Frequency": 300,
+        "Timeout": 120,
+        "RetryEnabled": true,
+        "Locations": [
+          {
+            "Id": "emea-se-sto-edge"
+          },
+          {
+            "Id": "emea-ru-msa-edge"
+          },
+          {
+            "Id": "emea-gb-db3-azr"
+          }
+        ],
+        "Kind": "ping",
+        "Configuration": {
+          "WebTest": "[concat('<WebTest Name=\"', parameters('appInsightsName'), '-at-', parameters('availabilityTests')[copyIndex('webTestsCopy')].nameSuffix, '\"',  ' Id=\"', parameters('availabilityTests')[copyIndex('webTestsCopy')].guid,'\"    Enabled=\"True\" CssProjectStructure=\"\" CssIteration=\"\" Timeout=\"0\" WorkItemIds=\"\" xmlns=\"http://microsoft.com/schemas/VisualStudio/TeamTest/2010\" Description=\"\" CredentialUserName=\"\" CredentialPassword=\"\" PreAuthenticate=\"True\" Proxy=\"default\" StopOnError=\"False\" RecordedResultFile=\"\" ResultsLocale=\"\">        <Items>        <Request Method=\"GET\" Guid=\"a5f10126-e4cd-570d-961c-cea43999a200\" Version=\"1.1\" Url=\"', replace(parameters('availabilityTests')[copyIndex('webTestsCopy')].url, '&', '&amp;'),'\" ThinkTime=\"0\" Timeout=\"300\" ParseDependentRequests=\"True\" FollowRedirects=\"True\" RecordResult=\"True\" Cache=\"False\" ResponseTimeGoal=\"0\" Encoding=\"utf-8\" ExpectedHttpStatusCode=\"200\" ExpectedResponseUrl=\"\" ReportingName=\"\" IgnoreHttpStatusCode=\"False\" /></Items></WebTest>')]"
+	}
+      },
+      "dependsOn": [
+        "[resourceId('Microsoft.Insights/components', parameters('appInsightsName'))]"
+      ]
     }
   ],
   "outputs": {

--- a/templates/availability-test-alert.json
+++ b/templates/availability-test-alert.json
@@ -68,10 +68,17 @@
       "metadata": {
         "decsription": "Number of times the test can fail before an alert is sent."
       }
+    },
+    "resourceTags": {
+      "type": "object",
+      "defaultValue": {}
     }
   },
   "variables": {
-    "scopes": "[createArray(parameters('appInsightsId'), parameters('webTestId'))]"
+    "scopes": "[createArray(parameters('appInsightsId'), parameters('webTestId'))]",
+    "metricAlertTags": {
+      "[concat('hidden-link:', resourceId('Microsoft.Insights/components', parameters('appInsightsName')))]": "Resource"
+    }
   },
   "resources": [
     {
@@ -79,9 +86,7 @@
       "type": "microsoft.insights/metricalerts",
       "name": "[parameters('alertName')]",
       "location": "global",
-      "tags": {
-        "[concat('hidden-link:', resourceId('Microsoft.Insights/components', parameters('appInsightsName')))]": "Resource"
-      },
+      "tags": "[union(variables('metricAlertTags'), parameters('resourceTags'))]",
       "properties": {
         "description": "[parameters('alertDescriptionText')]",
         "severity": "[parameters('alertSeverity')]",

--- a/templates/dashboard.json
+++ b/templates/dashboard.json
@@ -50,9 +50,17 @@
       "metadata": {
         "description": "Optional array of container instance names to be monitored."
       }
+    },
+    "resourceTags": {
+      "type": "object",
+      "defaultValue": {}
     }
   },
   "variables": {
+    "dashboardTags": {
+      "hidden-title": "[toUpper(concat(parameters('serviceName'), ' Dashboard (', parameters('environment'), ')'))]",
+      "Environment": "[parameters('environment')]"
+    },
     "defaultCpuUsage": [
       {
         "resourceMetadata": {
@@ -134,12 +142,7 @@
       "name": "[concat(parameters('resourceGroupName'), '-dashboard')]",
       "type": "Microsoft.Portal/dashboards",
       "location": "[resourceGroup().location]",
-      "tags": {
-        "hidden-title": "[toUpper(concat(parameters('serviceName'), ' Dashboard (', parameters('environment'), ')'))]",
-        "Environment": "[parameters('environment')]",
-        "Parent Business": "TBC",
-        "Service Offering": "TBC"
-      },
+      "tags": "[union(variables('dashboardTags'), parameters('resourceTags'))]",
       "properties": {
         "lenses": {
           "0": {


### PR DESCRIPTION
This change incorporates the following two changes:

~~1. Removed the `Microsoft.Insights/webtests` resource from the `application-insights.json` template following a prior PR to move it into its own template file, `availability-tests.json`~~
2. Added `resourceTags` parameter to `dashboard.json`, `action-group.json` and `availability-test-alert.json` template files.