### PR TITLE
Added TLS version and data persistence features to templates.

### DIFF
--- a/templates/redis.json
+++ b/templates/redis.json
@@ -21,10 +21,49 @@
       "type": "bool",
       "defaultValue": false
     },
+    "minimumTlsVersion": {
+      "type": "string",
+      "defaultValue": "1.0",
+      "allowedValues": [
+        "1.0",
+        "1.1",
+        "1.2"
+       ]
+    },
+    "dataPersistence": {
+      "type": "string",
+      "defaultValue": "disabled",
+      "allowedValues": [
+        "disabled",
+        "rdb",
+        "aof"
+      ],
+      "metadata": {
+        "description": "Data persistence settings. Can only be used where the redisCacheSku is set to 'Premium'. Requires a storage account for this feature to be enabled."
+      }
+    },
+    "rdbBackupFrequencyMinutes": {
+      "type": "int",
+      "defaultValue": 60,
+      "metadata": {
+        "description": "Time between backups in minutes."
+      }
+    },
+    "storageConnectionString": {
+      "type": "string",
+      "defaultValue": "",
+      "metadata": {
+        "description": "Connection string of the storage account to store the Redis persistence data in. Redis will create a new container for each node. Only required if 'dataPersistence' is set to 'aof'."
+      }
+    },
     "resourceTags": {
       "type": "object",
       "defaultValue": {}
     }
+  },
+  "variables": {
+    "persistence-aof-config": "[if(and(equals(parameters('redisCacheSKU'), 'Premium'), equals(parameters('dataPersistence'), 'aof')), json(concat('{\"aof-backup-enabled\": \"true\", \"aof-storage-connection-string-0\": \"', parameters('storageConnectionString'), '\", \"aof-storage-connection-string-1\": \"', parameters('storageConnectionString'), '\"}')), json('{}'))]",
+    "persistence-rdb-config": "[if(and(equals(parameters('redisCacheSKU'), 'Premium'), equals(parameters('dataPersistence'), 'rdb')), json(concat('{\"rdb-backup-enabled\": \"true\", \"rdb-backup-frequency\": \"', string(parameters('rdbBackupFrequencyMinutes')), '\", \"rdb-storage-connection-string\": \"', parameters('storageConnectionString'), '\"}')), json('{}'))]"
   },
   "resources": [
     {
@@ -35,11 +74,13 @@
       "tags": "[parameters('resourceTags')]",
       "properties": {
         "enableNonSslPort": "[parameters('enableNonSslPort')]",
+        "minimumTlsVersion": "[parameters('minimumTlsVersion')]",
         "sku": {
           "capacity": "[parameters('redisCacheCapacity')]",
           "family": "[parameters('redisCacheFamily')]",
           "name": "[parameters('redisCacheSKU')]"
-        }
+        },
+        "redisConfiguration": "[union(variables('persistence-aof-config'), variables('persistence-rdb-config'))]"
       }
     }
   ],


### PR DESCRIPTION
The following changes have been made to the Redis template:

1. Added parameter to set minimum TLS version because MS will be setting the default minimum to 1.2 from March 31st. This parameter enables setting the TLS version in the template ahead of time for the purpose of de-risking. The default is set to the minumum, 1.0, to ensure backwards compatibility.
1. Added data peristence features. This change supports both RDB and AOF (currently in preview). Both modes require a storage account connection string and RDB additionally requires a backup frequency. All configurable through parameters. The template will only allow the data persistence features to be used when a Premium SKU is used; this is the minimum tier that supports this feature.