### PR TITLE
Added logic app for Slack alerting and optional integrations to actio…

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,6 +8,7 @@ one or more application in a service.
 2. [Branching](#Branching)
 3. [Resource naming and parameter metadata description properties](#Resource-naming-and-parameter-metadata-description-properties)
 4. [Property name formatting](#Property-name-formatting)
+5. [Logic App for Slack](#logic-app-for-slack)
 
 ### Usage
 
@@ -129,3 +130,13 @@ The convention of property name formatting, as used in the examples above:
 2. Variables: camelCase
 3. Resource Deployments: lowercase-with-hyphens
 4. Outputs: PascalCase (matching the release pipeline variables)
+
+### Logic App for Slack
+
+When deploying the logic app for Slack, after the initial deployment you will need to complete following manual steps to authorise the API connection with Slack the first time only. Until these steps are complete you will not be able to receive alerts in slack.
+1. Login to the [Azure portal](https://portal.azure.com)
+2. Go to the 'API Connection' blade
+3. Select the Slack API connection that has been deployed
+4. Select 'Edit API connection' under 'General' in the menu
+5. Click the 'Authorize' button and click 'Allow' in the pop-up window that opens
+6. Once the Authorization is complete click the 'Save' button in the Edit API connection pane that should still be open in the portal.

--- a/examples/example-linked-template.json
+++ b/examples/example-linked-template.json
@@ -43,6 +43,30 @@
       "metadata": {
         "description": "The email address of the alert email recipient."
       }
+    },
+    "resourceNamePrefix": {
+      "type": "string",
+      "metadata": {
+        "description": "The CIP naming prefix for the resource, e.g. s106d01-apply."
+      }
+    },
+    "environment": {
+      "type": "string",
+      "metadata": {
+        "description": "The name of the resource environment e.g. qa, staging, production."
+      }
+    },
+    "slackChannel": {
+      "type": "string",
+      "metadata": {
+        "description": "The Slack channel to post to."
+      }
+    },
+    "serviceName": {
+      "type": "string",
+      "metadata": {
+        "description": "The name of the service, e.g Apply."
+      }
     }
   },
   "variables": {
@@ -161,6 +185,32 @@
     },
     {
       "apiVersion": "2017-05-10",
+      "name": "logic-app-slack",
+      "type": "Microsoft.Resources/deployments",
+      "properties": {
+        "mode": "Incremental",
+        "templateLink": {
+          "uri": "[concat(variables('templateBaseUrl'), 'logic-app-slack.json')]",
+          "contentVersion": "1.0.0.0"
+        },
+        "parameters": {
+          "resourceNamePrefix": {
+            "value": "[parameters('resourceNamePrefix')]"
+          },
+          "environment": {
+            "value": "[parameters('environment')]"
+          },
+          "slackChannel": {
+            "value": "[parameters('alertSlackChannel')]"
+          },
+          "serviceName": {
+            "value": "[parameters('serviceName')]"
+          }
+        }
+      }
+    },
+    {
+      "apiVersion": "2017-05-10",
       "name": "action-group",
       "type": "Microsoft.Resources/deployments",
       "properties": {
@@ -175,11 +225,22 @@
           },
           "alertRecipientEmails": {
             "value": "[variables('alertRecipientEmails')]"
+          },
+          "logicAppReceivers": {
+            "value": [
+              {
+                "name": "Slack",
+                "resourceId": "[reference('logic-app-slack').outputs.logicAppResourceId.value]",
+                "callbackUrl": "[reference('logic-app-slack').outputs.WebHookURI.value]",
+                "useCommonAlertSchema": false
+              }
+            ]
           }
         }
       },
       "dependsOn": [
-        "app-insights"
+        "app-insights",
+        "logic-app-slack"
       ]
     },
     {

--- a/templates/action-group.json
+++ b/templates/action-group.json
@@ -15,6 +15,13 @@
         "description": "Array of email recipient objects to send alerts to. Each email recipient objectsshould have the variables 'displayName' and 'emailAddress'."
       }
     },
+    "logicAppReceivers": {
+      "defaultValue": [],
+      "type": "array",
+      "metadata": {
+        "description": "Array of logic app receiver objects."
+      }
+    },
     "resourceTags": {
       "type": "object",
       "defaultValue": {}
@@ -52,7 +59,7 @@
         "azureAppPushReceivers": [],
         "automationRunbookReceivers": [],
         "voiceReceivers": [],
-        "logicAppReceivers": [],
+        "logicAppReceivers": "[parameters('logicAppReceivers')]",
         "azureFunctionReceivers": []
       }
     }

--- a/templates/logic-app-slack.json
+++ b/templates/logic-app-slack.json
@@ -1,0 +1,236 @@
+{
+  "$schema": "https://schema.management.azure.com/schemas/2015-01-01/deploymentTemplate.json#",
+  "contentVersion": "1.0.0.0",
+  "parameters": {
+    "resourceNamePrefix": {
+      "type": "string",
+      "metadata": {
+        "description": "The CIP naming prefix for the resource, e.g. s106d01-apply."
+      }
+    },
+    "environment": {
+      "type": "string",
+      "metadata": {
+        "description": "The name of the resource environment e.g. qa, staging, production."
+      }
+    },
+    "slackChannel": {
+      "type": "string",
+      "metadata": {
+        "description": "The Slack channel to post to."
+      }
+    },
+    "serviceName": {
+      "type": "string",
+      "metadata": {
+        "description": "The name of the service, e.g Apply."
+      }
+    },
+    "slackIconUrl": {
+      "type": "string",
+      "defaultValue": "https://www.denodo.com/sites/default/files/public/images/azure-icon.png",
+      "metadata": {
+        "description": "URL pointing to Icon to display against the Alert App in Slack."
+      }
+    },
+    "resourceTags": {
+      "type": "object",
+      "defaultValue": {}
+    }
+  },
+  "variables": {
+    "slackApiConnectionName": "[concat(parameters('resourceNamePrefix'), '-apic-slack')]",
+    "logicAppName": "[concat(parameters('resourceNamePrefix'), '-la-slack-alerts')]"
+  },
+  "resources": [
+    {
+      "apiVersion": "2016-06-01",
+      "name": "[variables('slackApiConnectionName')]",
+      "type": "Microsoft.Web/connections",
+      "location": "[resourceGroup().location]",
+      "tags": "[parameters('resourceTags')]",
+      "properties": {
+        "api": {
+          "id": "[concat(subscription().id,'/providers/Microsoft.Web/locations/', resourceGroup().location, '/managedApis/slack')]"
+        },
+        "displayName": "Slack",
+        "customParameterValues": {}
+      }
+    },
+    {
+      "apiVersion": "2019-05-01",
+      "name": "[variables('logicAppName')]",
+      "type": "Microsoft.Logic/workflows",
+      "location": "[resourceGroup().location]",
+      "tags": "[parameters('resourceTags')]",
+      "properties": {
+        "state": "Enabled",
+        "definition": {
+          "$schema": "https://schema.management.azure.com/providers/Microsoft.Logic/schemas/2016-06-01/workflowdefinition.json#",
+          "contentVersion": "1.0.0.0",
+          "parameters": {
+            "$connections": {
+              "defaultValue": {},
+              "type": "Object"
+            }
+          },
+          "triggers": {
+            "manual": {
+              "type": "request",
+              "kind": "Http",
+              "inputs": {
+                "schema": {
+                  "properties": {
+                    "data": {
+                      "properties": {
+                        "context": {
+                          "properties": {
+                            "activityLog": {
+                              "properties": {
+                                "authorization": {
+                                  "properties": {
+                                    "action": {
+                                      "type": "string"
+                                    },
+                                    "scope": {
+                                      "type": "string"
+                                    }
+                                  },
+                                  "type": "object"
+                                },
+                                "caller": {
+                                  "type": "string"
+                                },
+                                "claims": {
+                                  "type": "string"
+                                },
+                                "httpRequest": {
+                                  "type": "string"
+                                }
+                              },
+                              "type": "object"
+                            }, 
+                            "description": {
+                              "type": "string"
+                            },
+                            "resourceGroupName": {
+                              "type": "string"
+                            },
+                            "resourceId": {
+                              "type": "string"
+                            },
+                            "resourceName": {
+                              "type": "string"
+                            },
+                            "resourceType": {
+                              "type": "string"
+                            }
+                          },
+                          "type": "object"
+                        },
+                        "properties": {
+                          "properties": {},
+                          "type": "object"
+                        },
+                        "status": {
+                          "type": "string"
+                        }
+                      },
+                      "type": "object"
+                    },
+                    "schemaId": {
+                      "type": "string"
+                    }
+                  },
+                  "type": "object"
+                }
+              }
+            }
+          },
+          "actions": {
+            "Condition": {
+              "actions": {
+                "Post_Activated_Alert_Message": {
+                  "inputs": {
+                    "host": {
+                      "connection": {
+                        "name": "@parameters('$connections')['slack']['connectionId']"
+                      }
+                    },
+                    "method": "post",
+                    "path": "/chat.postMessage",
+                    "queries": {
+                      "channel": "[parameters('slackChannel')]",
+                      "icon_url": "[parameters('slackIconUrl')]",
+                      "text": "[concat(':rotating_light: @{triggerBody()?[''data'']?[''context'']?[''description'']} on @{triggerBody()?[''data'']?[''context'']?[''resourceName'']} in *', parameters('environment'), '* has triggered.')]",
+                      "username": "[concat(toUpper(first(parameters('serviceName'))), skip(parameters('serviceName'), 1), ' Azure Alerts')]"
+                    }
+                  },
+                  "runAfter": {},
+                  "type": "ApiConnection"
+                }
+              },
+              "else": {
+                "actions": {
+                  "Post_Deactivated_Alert_Message": {
+                    "inputs": {
+                      "host": {
+                        "connection": {
+                          "name": "@parameters('$connections')['slack']['connectionId']"
+                        }
+                      },
+                      "method": "post",
+                      "path": "/chat.postMessage",
+                      "queries": {
+                        "channel": "[parameters('slackChannel')]",
+                        "icon_url": "[parameters('slackIconUrl')]",
+                        "text": "[concat(':heavy_check_mark: @{triggerBody()?[''data'']?[''context'']?[''description'']} on @{triggerBody()?[''data'']?[''context'']?[''resourceName'']} in *', parameters('environment'), '* is resolved.')]",
+                        "username": "[concat(toUpper(first(parameters('serviceName'))), skip(parameters('serviceName'), 1), ' Azure Alerts')]"
+                      }
+                    },
+                    "runAfter": {},
+                    "type": "ApiConnection"
+                  }
+                }
+              },
+              "expression": {
+                "and": [
+                  {
+                    "equals": [ "@triggerBody()?['data']?['status']", "Activated" ]
+                  }
+                ]
+              },
+              "runAfter": {},
+              "type": "If"
+            }
+          },
+          "outputs": {}
+        },
+        "parameters": {
+          "$connections": {
+            "value": {
+              "slack": {
+                "id": "[concat(subscription().id,'/providers/Microsoft.Web/locations/', resourceGroup().location, '/managedApis/slack')]",
+                "connectionId": "[resourceId('Microsoft.Web/connections', variables('slackApiConnectionName'))]",
+                "connectionName": "slack"
+              }
+            }
+          }
+        }
+      },
+      "dependsOn": [
+        "[resourceId('Microsoft.Web/connections', variables('slackApiConnectionName'))]"
+      ]
+    }
+  ],
+  "outputs": {
+    "logicAppResourceId": {
+      "type": "string",
+      "value": "[resourceId('Microsoft.Logic/workflows', variables('logicAppName'))]"
+    },
+    "WebHookURI": {
+      "type": "string",
+      "value": "[listCallbackURL(concat(resourceId('Microsoft.Logic/workflows/', variables('logicAppName')), '/triggers/manual'), '2016-06-01').value]"
+    }
+  }
+}


### PR DESCRIPTION
This PR introduces availability alerting into Slack by way of using and API connection to Slack and a logic app to translate the Azure alerts into a format compatible with Slack.

Changes included:

1. `templates/logic-app-slack.json`  - New template file
2. `templates/actions-groups.json` - Added logic app template parameters with empty default value
3. `README.md` - Added guidance to authorise the Slack API connection after the first template deployment
4. `examples/example-linked-template.json` - Example of using these new features