### PR TITLE
Parameterised availability test locations

### DIFF
--- a/templates/availability-tests.json
+++ b/templates/availability-tests.json
@@ -15,6 +15,23 @@
         "description": "Array of availability test objects to configure URLs to perform availability tests for. Availability test objects must contain the following the variables 'nameSuffix', 'url' and 'guid'."
       }
     },
+    "testLocations": {
+      "type": "array",
+      "defaultValue": [
+        {
+          "Id": "emea-se-sto-edge"
+        },
+        {
+          "Id": "emea-ru-msa-edge"
+        },
+        {
+          "Id": "emea-gb-db3-azr"
+        }
+      ],
+      "metadata": {
+        "description": "The originating locations of the availability tests. The defaults correspond to UK South, UK West and North Europe."
+      }
+    },
     "resourceTags": {
       "type": "object",
       "defaultValue": {}
@@ -44,17 +61,7 @@
         "Frequency": 300,
         "Timeout": 120,
         "RetryEnabled": true,
-        "Locations": [
-          {
-            "Id": "emea-se-sto-edge"
-          },
-          {
-            "Id": "emea-ru-msa-edge"
-          },
-          {
-            "Id": "emea-gb-db3-azr"
-          }
-        ],
+        "Locations": "[parameters('testLocations')]",
         "Kind": "ping",
         "Configuration": {
           "WebTest": "[concat('<WebTest Name=\"', parameters('appInsightsName'), '-at-', parameters('availabilityTests')[copyIndex('webTestsCopy')].nameSuffix, '\"',  ' Id=\"', parameters('availabilityTests')[copyIndex('webTestsCopy')].guid,'\"    Enabled=\"True\" CssProjectStructure=\"\" CssIteration=\"\" Timeout=\"0\" WorkItemIds=\"\" xmlns=\"http://microsoft.com/schemas/VisualStudio/TeamTest/2010\" Description=\"\" CredentialUserName=\"\" CredentialPassword=\"\" PreAuthenticate=\"True\" Proxy=\"default\" StopOnError=\"False\" RecordedResultFile=\"\" ResultsLocale=\"\">        <Items>        <Request Method=\"GET\" Guid=\"a5f10126-e4cd-570d-961c-cea43999a200\" Version=\"1.1\" Url=\"', replace(parameters('availabilityTests')[copyIndex('webTestsCopy')].url, '&', '&amp;'),'\" ThinkTime=\"0\" Timeout=\"300\" ParseDependentRequests=\"True\" FollowRedirects=\"True\" RecordResult=\"True\" Cache=\"False\" ResponseTimeGoal=\"0\" Encoding=\"utf-8\" ExpectedHttpStatusCode=\"200\" ExpectedResponseUrl=\"\" ReportingName=\"\" IgnoreHttpStatusCode=\"False\" /></Items></WebTest>')]"


### PR DESCRIPTION
This change introduces the ability to change the default availability test locations set in the template by specifying them as a parameter array. The default value of this parameter sets the test locations as they were prior to this change ensuring backwards compatibility for existing deployments using this template.