### PR TITLE
Change codeowners

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,3 +1,3 @@
 
 # Assign the following team as codeowners for this repository
-*      @chelnak @EwanNoble @smneal @OutKa5t @rizzkhan1 @tpinney
+*      @tpinney @saliceti @vigneshmsft @karthikdfe


### PR DESCRIPTION
Added the Cap Gemini team as code owners and removed the BAE Coventry users.