### PR TITLE
use placedholder name, if not using custom hostname

### DIFF
--- a/templates/app-service-linux.json
+++ b/templates/app-service-linux.json
@@ -149,7 +149,7 @@
     {
       "type": "Microsoft.Web/sites/hostnameBindings",
       "condition": "[variables('useCustomDomains')]",
-      "name": "[concat(parameters('appServiceName'), '/', if(variables('useCustomDomains'), parameters('customDomains')[copyIndex('customDomainsIndex')].domainName, ''))]",
+      "name": "[concat(parameters('appServiceName'), '/', if(variables('useCustomDomains'), parameters('customDomains')[copyIndex('customDomainsIndex')].domainName, 'placeholder'))]",
       "apiVersion": "2016-08-01",
       "location": "[resourceGroup().location]",
       "tags": "[parameters('resourceTags')]",


### PR DESCRIPTION
ARM validation fails if custom domainname is not specified.
Use a placeholder name if custom hostname is not specified.