### PR TITLE
useCustomDomains condition for empty domainName

### DIFF
--- a/templates/app-service-linux.json
+++ b/templates/app-service-linux.json
@@ -97,7 +97,7 @@
   },
   "variables": {
     "appServicePlanId": "[resourceId(parameters('appServicePlanResourceGroup'), 'Microsoft.Web/serverfarms', parameters('appServicePlanName'))]",
-    "useCustomDomains": "[greater(length(parameters('customDomains')), 0)]"
+    "useCustomDomains": "[and(greater(length(parameters('customDomains')), 0), greater(length(parameters('customDomains')[0].domainName), 0))]"
   },
   "resources": [
     {


### PR DESCRIPTION
useCustomDomains  to true if customDomains array is null or if the first element is empty.
if `customHostName` is not passed customDomains length will still be 1, but first element will be empty.