### PR TITLE
Prometheus Module should return the application id

### DIFF
--- a/terraform/modules/postgres_prometheus_exporter/resources.tf
+++ b/terraform/modules/postgres_prometheus_exporter/resources.tf
@@ -1,6 +1,6 @@
 resource "cloudfoundry_app" "postgres-exporter" {
   name             = "postgres-exporter-${var.name}"
-  space            =  var.install_space_id
+  space            =  var.monitor_space_id
   docker_image     =  "wrouesnel/postgres_exporter"
   ports            = [9187]
   routes {
@@ -23,7 +23,7 @@ output endpoint {
 
 resource cloudfoundry_route postgres-exporter {
   domain   = data.cloudfoundry_domain.cloudapps.id
-  space    = var.install_space_id
+  space    = var.monitor_space_id
   hostname = "postgres-exporter-${var.name}"
 }
 

--- a/terraform/modules/prometheus/config.tf
+++ b/terraform/modules/prometheus/config.tf
@@ -1,5 +1,5 @@
 locals {
-   config_file                = var.config_file == "" ? "${path.module}/templates/prometheus.yml.tmpl" : var.config_file
+  config_file = var.config_file == "" ? "${path.module}/templates/prometheus.yml.tmpl" : var.config_file
 }
 
 data archive_file config {
@@ -7,7 +7,7 @@ data archive_file config {
   output_path = "${path.module}/files/prometheus.zip"
 
   source {
-    content  = templatefile(  local.config_file , merge( local.template_variable_map, var.additional_variable_map ) )
+    content  = templatefile(local.config_file, merge(local.template_variable_map, var.additional_variable_map))
     filename = "prometheus.yml"
   }
 

--- a/terraform/modules/prometheus/data.tf
+++ b/terraform/modules/prometheus/data.tf
@@ -1,3 +1,3 @@
 data "cloudfoundry_domain" "cloudapps" {
- name = "london.cloudapps.digital"
+  name = "london.cloudapps.digital"
 }

--- a/terraform/modules/prometheus/input.tf
+++ b/terraform/modules/prometheus/input.tf
@@ -3,11 +3,11 @@ variable name {}
 variable paas_prometheus_exporter_endpoint {}
 variable alertmanager_endpoint {}
 
-variable additional_variable_map{
+variable additional_variable_map {
   type = map
   default = {
-     do_nothing = "Nothing"
-  } 
+    do_nothing = "Nothing"
+  }
 }
 
 variable alert_rules {

--- a/terraform/modules/prometheus/output.tf
+++ b/terraform/modules/prometheus/output.tf
@@ -2,11 +2,10 @@ output endpoint {
   value = cloudfoundry_route.prometheus.endpoint
 }
 
-output id {
-  value = cloudfoundry_route.prometheus.id
+output app_id {
+  value = cloudfoundry_app.prometheus.id
 }
 
-
 output config {
-   value = local.config_file 
+  value = local.config_file
 }

--- a/terraform/modules/redis_prometheus_exporter/resources.tf
+++ b/terraform/modules/redis_prometheus_exporter/resources.tf
@@ -1,7 +1,7 @@
 
 resource "cloudfoundry_app" "redis-exporter" {
   name             = "redis-exporter-${var.name}"
-  space            =  var.install_space_id
+  space            =  var.monitor_space_id
   docker_image     =  "oliver006/redis_exporter:latest"
   ports            = [9187]
 
@@ -21,7 +21,7 @@ output redis_data {
 }
 
 resource cloudfoundry_route redis_exporter {
-  space    = var.install_space_id
+  space    = var.monitor_space_id
   domain   = data.cloudfoundry_domain.cloudapps.id
   hostname = "redis-exporter-${var.name}"
 }


### PR DESCRIPTION
The Prometheus module returns **id** this is not clear what it is the id of.

removed  **id** the route_id as it isn't needed
Added **app_id** to return the identifier of the application, which can be consumed elsewhere.