### PR TITLE
Add the ability to set version of Grafana

### DIFF
--- a/terraform/modules/grafana/README.md
+++ b/terraform/modules/grafana/README.md
@@ -42,3 +42,10 @@ module "grafana" {
      additional_variable_map = local.map
 }
 ```
+
+### Grafana Version
+This file allows you to specify the version of Grafana to the build pack, by default it is 6.5.1 but this can be overridden
+```
+# Define your grafana version here
+6.5.1
+```

--- a/terraform/modules/grafana/README.md
+++ b/terraform/modules/grafana/README.md
@@ -15,6 +15,7 @@ By default the template now supports integration with google logins. The ID must
    datasource_directory    OPTIONAL
    configuration_file      OPTIONAL
    plugins_list            OPTIONAL
+   runtime_version         OPTIONAL
 ```
 
 ### Plugins List
@@ -43,9 +44,3 @@ module "grafana" {
 }
 ```
 
-### Grafana Version
-This file allows you to specify the version of Grafana to the build pack, by default it is 6.5.1 but this can be overridden
-```
-# Define your grafana version here
-6.5.1
-```

--- a/terraform/modules/grafana/config.tf
+++ b/terraform/modules/grafana/config.tf
@@ -2,6 +2,7 @@ locals {
     tmp_data    = var.datasource_directory == "" ? "${path.module}/datasources/"       : var.datasource_directory
     tmp_dash    = var.dashboard_directory  == "" ? "${path.module}/dashboards/"        : var.dashboard_directory
     tmp_plug    = var.plugins_file         == "" ? "${path.module}/config/plugins.txt" : var.plugins_file
+    tmp_runtime = var.runtime_file         == "" ? "${path.module}/config/runtime.txt" : var.runtime_file
     tmp_config  = var.configuration_file   == "" ? "${path.module}/config/grafana.ini" : var.configuration_file
 
     dashboards = fileset("${local.tmp_dash}", "*.json")
@@ -17,6 +18,11 @@ data archive_file config {
   source {
     content  = file( "${local.tmp_plug}" )
     filename = "plugins.txt"
+  }
+
+  source {
+    content  = file( "${local.tmp_runtime}" )
+    filename = "runtime.txt"
   }
 
   source {

--- a/terraform/modules/grafana/config.tf
+++ b/terraform/modules/grafana/config.tf
@@ -2,8 +2,9 @@ locals {
     tmp_data    = var.datasource_directory == "" ? "${path.module}/datasources/"       : var.datasource_directory
     tmp_dash    = var.dashboard_directory  == "" ? "${path.module}/dashboards/"        : var.dashboard_directory
     tmp_plug    = var.plugins_file         == "" ? "${path.module}/config/plugins.txt" : var.plugins_file
-    tmp_runtime = var.runtime_file         == "" ? "${path.module}/config/runtime.txt" : var.runtime_file
     tmp_config  = var.configuration_file   == "" ? "${path.module}/config/grafana.ini" : var.configuration_file
+
+    tmp_runtime = "${path.module}/config/runtime.txt"
 
     dashboards = fileset("${local.tmp_dash}", "*.json")
     datasources = fileset("${local.tmp_data}", "*.yml.tmpl")
@@ -21,7 +22,7 @@ data archive_file config {
   }
 
   source {
-    content  = file( "${local.tmp_runtime}" )
+    content  = templatefile( "${local.tmp_runtime}" , var.runtime_version )
     filename = "runtime.txt"
   }
 

--- a/terraform/modules/grafana/config/runtime.txt
+++ b/terraform/modules/grafana/config/runtime.txt
@@ -1,2 +1,2 @@
 # Define your grafana version here
-6.5.1
+${runtime_version}

--- a/terraform/modules/grafana/config/runtime.txt
+++ b/terraform/modules/grafana/config/runtime.txt
@@ -1,0 +1,2 @@
+# Define your grafana version here
+6.5.1

--- a/terraform/modules/grafana/input.tf
+++ b/terraform/modules/grafana/input.tf
@@ -26,6 +26,10 @@ variable plugins_file {
     default = ""
 }
 
+variable runtime_file {
+    default = ""
+}
+
 locals {
   template_variable_map = {
     prometheus_endpoint = var.prometheus_endpoint

--- a/terraform/modules/grafana/input.tf
+++ b/terraform/modules/grafana/input.tf
@@ -26,8 +26,8 @@ variable plugins_file {
     default = ""
 }
 
-variable runtime_file {
-    default = ""
+variable runtime_version {
+    default = "6.5.1"
 }
 
 locals {

--- a/terraform/modules/grafana/providers.tf
+++ b/terraform/modules/grafana/providers.tf
@@ -1,0 +1,8 @@
+terraform {
+  required_providers {
+    cloudfoundry = {
+      source  = "cloudfoundry-community/cloudfoundry"
+      version = "~> 0.12.6"
+    }
+  }
+}


### PR DESCRIPTION
The buildpack provides an option to send a file called runtime.txt as an option, this file contains the version of Grafana.
This PR allows the terraform to pass a custom runtime.txt file in and allow the users the ability to set their own version of Grafana