### PR TITLE
Add the ability to pass in the Grafana Runtime Version

### DIFF
--- a/terraform/modules/grafana/README.md
+++ b/terraform/modules/grafana/README.md
@@ -40,5 +40,6 @@ module "grafana" {
      datasource_directory    = local.datasource_directory
      prometheus_endpoint     = "https://prometheus.london.cloudapps.digital"
      additional_variable_map = local.map
+     runtime_version         = x.x.x
 }
 ```

--- a/terraform/modules/grafana/config.tf
+++ b/terraform/modules/grafana/config.tf
@@ -8,6 +8,11 @@ data archive_file config {
   }
 
   source {
+    content  = templatefile("${local.tmp_runtime}", {  runtime_version = var.runtime_version } )
+    filename = "runtime.txt"
+  }
+
+  source {
     content  = templatefile("${local.tmp_config}", var.additional_variable_map)
     filename = "grafana.ini"
   }

--- a/terraform/modules/grafana/config/runtime.txt
+++ b/terraform/modules/grafana/config/runtime.txt
@@ -1,0 +1,1 @@
+${runtime_version}

--- a/terraform/modules/grafana/input.tf
+++ b/terraform/modules/grafana/input.tf
@@ -14,11 +14,15 @@ variable dashboard_directory { default = "" }
 
 variable datasource_directory { default = "" }
 
+variable runtime_version  { default = "6.5.1" }
+
 locals {
   tmp_data   = var.datasource_directory == "" ? "${path.module}/datasources/" : var.datasource_directory
   tmp_dash   = var.dashboard_directory == "" ? "${path.module}/dashboards/" : var.dashboard_directory
   tmp_plug   = var.plugins_file == "" ? "${path.module}/config/plugins.txt" : var.plugins_file
   tmp_config = var.configuration_file == "" ? "${path.module}/config/grafana.ini" : var.configuration_file
+
+  tmp_runtime = "${path.module}/config/runtime.txt"
 
   dashboards  = fileset("${local.tmp_dash}", "*.json")
   datasources = fileset("${local.tmp_data}", "*.yml.tmpl")


### PR DESCRIPTION
There is a method to select the version of Grafana in the buildpack, using the runtime.txt file.

This PR allows the values of the runtime ( default 6.5.1 ) to be passed to the buildpack via terraform, thus allowing the team to select the version of grafana they need.