### PR TITLE
Increase prometheus memory

### DIFF
--- a/templates/metric-alert.json
+++ b/templates/metric-alert.json
@@ -1,0 +1,189 @@
+{
+    "$schema": "https://schema.management.azure.com/schemas/2015-01-01/deploymentTemplate.json#",
+    "contentVersion": "1.0.0.0",
+    "parameters": {
+        "subscription": {
+            "type": "string",
+            "defaultValue": "",
+            "minLength": 1,
+            "metadata": {
+                "description": "subscriptionID"
+            }
+        },
+        "actionGroupName": {
+            "type": "string",
+            "defaultValue": "",
+            "minLength": 1,
+            "metadata": {
+                "description": "Name of ActionGroup to send notification"
+            }
+        },
+        "resourceInstance": {
+            "type": "string",
+            "defaultValue": "",
+            "minLength": 1,
+            "metadata": {
+                "description": "Name of App Service Plan instance"
+            }
+        },
+        "resourceGroup": {
+            "type": "string",
+            "defaultValue": "",
+            "minLength": 1,
+            "metadata": {
+                "description": "Name of ResourceGroup"
+            }
+        },
+        "alertName": {
+            "type": "string",
+            "defaultValue": "ttapi-App-service-Plan-Cpu-Monitor",
+            "minLength": 1,
+            "metadata": {
+                "description": "Name of the alert"
+            }
+        },
+        "alertDescription": {
+            "type": "string",
+            "defaultValue": "This is a metric alert to monitor ttapi-App-service-Plan Cpu",
+            "metadata": {
+                "description": "Description of alert"
+            }
+        },
+        "alertSeverity": {
+            "type": "int",
+            "defaultValue": 3,
+            "allowedValues": [
+                0,
+                1,
+                2,
+                3,
+                4
+            ],
+            "metadata": {
+                "description": "Severity of alert {0,1,2,3,4}"
+            }
+        },
+        "isEnabled": {
+            "type": "bool",
+            "defaultValue": true,
+            "metadata": {
+                "description": "Specifies whether the alert is enabled"
+            }
+        },
+        "metricName": {
+            "type": "string",
+            "defaultValue": "CpuPercentage",
+            "minLength": 1,
+            "metadata": {
+                "description": "Name of the metric used in the comparison to activate the alert."
+            }
+        },
+        "operator": {
+            "type": "string",
+            "defaultValue": "GreaterThan",
+            "allowedValues": [
+                "Equals",
+                "NotEquals",
+                "GreaterThan",
+                "GreaterThanOrEqual",
+                "LessThan",
+                "LessThanOrEqual"
+            ],
+            "metadata": {
+                "description": "Operator comparing the current value with the threshold value."
+            }
+        },
+        "threshold": {
+            "type": "string",
+            "defaultValue": "70",
+            "metadata": {
+                "description": "The threshold value at which the alert is activated."
+            }
+        },
+        "timeAggregation": {
+            "type": "string",
+            "defaultValue": "Average",
+            "allowedValues": [
+                "Average",
+                "Minimum",
+                "Maximum",
+                "Total",
+                "Count"
+            ],
+            "metadata": {
+                "description": "How the data that is collected should be combined over time."
+            }
+        },
+        "windowSize": {
+            "type": "string",
+            "defaultValue": "PT5M",
+            "allowedValues": [
+                "PT1M",
+                "PT5M",
+                "PT15M",
+                "PT30M",
+                "PT1H",
+                "PT6H",
+                "PT12H",
+                "PT24H"
+            ],
+            "metadata": {
+                "description": "Period of time used to monitor alert activity based on the threshold. Must be between one minute and one day. ISO 8601 duration format."
+            }
+        },
+        "evaluationFrequency": {
+            "type": "string",
+            "defaultValue": "PT1M",
+            "allowedValues": [
+                "PT1M",
+                "PT5M",
+                "PT15M",
+                "PT30M",
+                "PT1H"
+            ],
+            "metadata": {
+                "description": "how often the metric alert is evaluated represented in ISO 8601 duration format"
+            }
+        }
+    },
+    "variables": {
+        "actionGroupId": "[concat('/subscriptions/',parameters('subscription'),'/resourceGroups/',parameters('resourceGroup'),'/providers/microsoft.insights/actionGroups/', parameters('actionGroupName'))]",
+        "resourceId": "[concat('/subscriptions/',parameters('subscription'),'/resourceGroups/',parameters('resourceGroup'),'/providers/Microsoft.Web/serverFarms/', parameters('resourceInstance'))]"
+    },
+    "resources": [
+        {
+            "name": "[parameters('alertName')]",
+            "type": "Microsoft.Insights/metricAlerts",
+            "location": "global",
+            "apiVersion": "2018-03-01",
+            "tags": {},
+            "properties": {
+                "description": "[parameters('alertDescription')]",
+                "severity": "[parameters('alertSeverity')]",
+                "enabled": "[parameters('isEnabled')]",
+                "scopes": ["[variables('resourceId')]"],
+                "evaluationFrequency":"[parameters('evaluationFrequency')]",
+                "windowSize": "[parameters('windowSize')]",
+                "criteria": {
+                    "odata.type": "Microsoft.Azure.Monitor.SingleResourceMultipleMetricCriteria",
+                    "allOf": [
+                        {
+                            "criterionType" : "StaticThresholdCriterion",
+                            "name" : "1st criterion",
+                            "metricName": "[parameters('metricName')]",
+                            "dimensions":[],
+                            "operator": "[parameters('operator')]",
+                            "threshold" : "[parameters('threshold')]",
+                            "timeAggregation": "[parameters('timeAggregation')]"
+                        }
+                    ]
+                },
+                "actions": [
+                    {
+                        "actionGroupId": "[variables('actionGroupId')]"
+                    }
+                ]
+            }
+        }
+    ]
+}

--- a/terraform/modules/prometheus/input.tf
+++ b/terraform/modules/prometheus/input.tf
@@ -14,6 +14,18 @@ variable alert_rules {
   default = ""
 }
 
+variable memory {
+  default = 1024
+}
+
+variable instances {
+  default = 1
+}
+
+variable disk_quota {
+  default = 1024
+}
+
 variable config_file {
   default = ""
 }

--- a/terraform/modules/prometheus/resources.tf
+++ b/terraform/modules/prometheus/resources.tf
@@ -8,7 +8,9 @@ resource cloudfoundry_app prometheus {
   name             = "prometheus-${var.name}"
   space            = var.space_id
   path             = data.archive_file.config.output_path
-  memory           = "5120"
+  memory           = var.memory
+  instances        = var.instances
+  disk_quota       = var.disk_quota
   source_code_hash = data.archive_file.config.output_base64sha256
   buildpack        = "https://github.com/alphagov/prometheus-buildpack.git"
   routes {

--- a/terraform/modules/prometheus/resources.tf
+++ b/terraform/modules/prometheus/resources.tf
@@ -8,6 +8,7 @@ resource cloudfoundry_app prometheus {
   name             = "prometheus-${var.name}"
   space            = var.space_id
   path             = data.archive_file.config.output_path
+  memory           = "5120"
   source_code_hash = data.archive_file.config.output_base64sha256
   buildpack        = "https://github.com/alphagov/prometheus-buildpack.git"
   routes {


### PR DESCRIPTION
with a large dashboard 1GB of memory often fills, causing a application reboot.
Increased the maximum permissible memory to 5G 