### PR TITLE
Monitoring/alertmanager/templates

### DIFF
--- a/terraform/modules/alertmanager/README.md
+++ b/terraform/modules/alertmanager/README.md
@@ -8,6 +8,8 @@ It is deployed using the official docker image.
    monitoring_space_id         MANDATORY
    monitoring_instance_name    MANDATORY
    config                      OPTIONAL
+   slack_url                   OPTIONAL
+   slack_channel               OPTIONAL
 ```
 
 - **monitoring_instance_name:** A unique name given to the application
@@ -21,5 +23,10 @@ module alertmanager {
    monitoring_space_id      = data.cloudfoundry_space.space.id
    monitoring_instance_name = "test-alertmanager"
    config                   = file("${path.module}/files/alertmanager.yml")
+   slack_url                = https://hooks.slack.com/services/XXXXXXXXX/YYYYYYYYYYY/xxxxxxxxxxxxxxxxxxxxxxxx
+   slack_channel            = mychannel
 }
 ```
+
+### Templates
+A default set of slack templates have been provided

--- a/terraform/modules/alertmanager/README.md
+++ b/terraform/modules/alertmanager/README.md
@@ -28,5 +28,19 @@ module alertmanager {
 }
 ```
 
+### Prometheus alerts
+
+```
+      - alert: TooManyRequests
+        expr: 'sum(increase(tta_requests_total{path!~"csp_reports",status=~"429"}[1m])) > 0'
+        labels:
+          severity: high
+        annotations:
+          summary: Alert when any user hits a rate limit (excluding the /csp_reports endpoint).
+          runbook: https://dfedigital.atlassian.net/wiki/spaces/GGIT/pages/2152497153/Rate+Limit
+```
+
+The severity should be one of high, medium or low
+
 ### Templates
 A default set of slack templates have been provided

--- a/terraform/modules/alertmanager/README.md
+++ b/terraform/modules/alertmanager/README.md
@@ -44,3 +44,7 @@ The severity should be one of high, medium or low
 
 ### Templates
 A default set of slack templates have been provided
+
+### Acknowledgements to
+https://gist.github.com/milesbxf/e2744fc90e9c41b47aa47925f8ff6512
+

--- a/terraform/modules/alertmanager/config/alertmanager.yml
+++ b/terraform/modules/alertmanager/config/alertmanager.yml
@@ -1,5 +1,37 @@
+global:
+ resolve_timeout: 1m
+ slack_api_url: '${slack_url}'
+
 route:
-  receiver: dummy
+ receiver: 'slack-notifications'
+ group_interval: 1m
+ repeat_interval: 1m
+
+templates:
+  - './slack.tmpl'
 
 receivers:
-  - name: dummy
+- name: slack-notifications
+  slack_configs:
+  - channel: '#${slack_channel}'
+    send_resolved: true
+    title: '{{ template "slack.monzo.title" . }}'
+    icon_emoji: '{{ template "slack.monzo.icon_emoji" . }}'
+    color: '{{ template "slack.monzo.color" . }}'
+    text: '{{ template "slack.monzo.text" . }}'
+    actions:
+    - type: button
+      text: 'Runbook :green_book:'
+      url: '{{ (index .Alerts 0).Annotations.runbook }}'
+    - type: button
+      text: 'Query :mag:'
+      url: '{{ (index .Alerts 0).GeneratorURL }}'
+    - type: button
+      text: 'Dashboard :grafana:'
+      url: '{{ (index .Alerts 0).Annotations.dashboard }}'
+    - type: button
+      text: 'Silence :no_bell:'
+      url: '{{ template "__alert_silence_link" . }}'
+    - type: button
+      text: '{{ template "slack.monzo.link_button_text" . }}'
+      url: '{{ .CommonAnnotations.link_url }}'

--- a/terraform/modules/alertmanager/config/alertmanager.yml
+++ b/terraform/modules/alertmanager/config/alertmanager.yml
@@ -16,9 +16,9 @@ receivers:
   - channel: '#${slack_channel}'
     send_resolved: true
     title: '{{ template "slack.monzo.title" . }}'
-    icon_emoji: '{{ template "slack.monzo.icon_emoji" . }}'
-    color: '{{ template "slack.monzo.color" . }}'
+    pretext: '{{ template "slack.monzo.pretext" . }}'
     text: '{{ template "slack.monzo.text" . }}'
+    color: '{{ template "slack.monzo.color" . }}'
     actions:
     - type: button
       text: 'Runbook :green_book:'
@@ -27,11 +27,8 @@ receivers:
       text: 'Query :mag:'
       url: '{{ (index .Alerts 0).GeneratorURL }}'
     - type: button
-      text: 'Dashboard :grafana:'
+      text: 'Dashboard :bar_chart:'
       url: '{{ (index .Alerts 0).Annotations.dashboard }}'
     - type: button
       text: 'Silence :no_bell:'
       url: '{{ template "__alert_silence_link" . }}'
-    - type: button
-      text: '{{ template "slack.monzo.link_button_text" . }}'
-      url: '{{ .CommonAnnotations.link_url }}'

--- a/terraform/modules/alertmanager/config/alertmanager.yml
+++ b/terraform/modules/alertmanager/config/alertmanager.yml
@@ -5,7 +5,7 @@ global:
 route:
  receiver: 'slack-notifications'
  group_interval: 1m
- repeat_interval: 1m
+ repeat_interval: 1h
 
 templates:
   - './slack.tmpl'

--- a/terraform/modules/alertmanager/config/slack.tmpl
+++ b/terraform/modules/alertmanager/config/slack.tmpl
@@ -1,0 +1,114 @@
+# This builds the silence URL.  We exclude the alertname in the range
+# to avoid the issue of having trailing comma separator (%2C) at the end
+# of the generated URL
+{{ define "__alert_silence_link" -}}
+    {{ .ExternalURL }}/#/silences/new?filter=%7B
+    {{- range .CommonLabels.SortedPairs -}}
+        {{- if ne .Name "alertname" -}}
+            {{- .Name }}%3D"{{- .Value -}}"%2C%20
+        {{- end -}}
+    {{- end -}}
+    alertname%3D"{{ .CommonLabels.alertname }}"%7D
+{{- end }}
+
+
+
+{{ define "__alert_severity_prefix" -}}
+    {{ if ne .Status "firing" -}}
+    :lgtm:
+    {{- else if eq .Labels.severity "critical" -}}
+    :fire:
+    {{- else if eq .Labels.severity "warning" -}}
+    :warning:
+    {{- else -}}
+    :question:
+    {{- end }}
+{{- end }}
+
+{{ define "__alert_severity_prefix_title" -}}
+    {{ if ne .Status "firing" -}}
+    :lgtm:
+    {{- else if eq .CommonLabels.severity "critical" -}}
+    :fire:
+    {{- else if eq .CommonLabels.severity "warning" -}}
+    :warning:
+    {{- else if eq .CommonLabels.severity "info" -}}
+    :information_source:
+    {{- else -}}
+    :question:
+    {{- end }}
+{{- end }}
+
+
+{{/* First line of Slack alerts */}}
+{{ define "slack.monzo.title" -}}
+    [{{ .Status | toUpper -}}
+    {{ if eq .Status "firing" }}:{{ .Alerts.Firing | len }}{{- end -}}
+    ] {{ template "__alert_severity_prefix_title" . }} {{ .CommonLabels.alertname }}
+{{- end }}
+
+
+{{/* Color of Slack attachment (appears as line next to alert )*/}}
+{{ define "slack.monzo.color" -}}
+    {{ if eq .Status "firing" -}}
+        {{ if eq .CommonLabels.severity "warning" -}}
+            warning
+        {{- else if eq .CommonLabels.severity "critical" -}}
+            danger
+        {{- else -}}
+            #439FE0
+        {{- end -}}
+    {{ else -}}
+    good
+    {{- end }}
+{{- end }}
+
+
+{{/* Emoji to display as user icon (custom emoji supported!) */}}
+{{ define "slack.monzo.icon_emoji" }}:prometheus:{{ end }}
+
+{{/* The test to display in the alert */}}
+{{ define "slack.monzo.text" -}}
+    {{ range .Alerts }}
+        {{- if .Annotations.message }}
+            {{ .Annotations.message }}
+        {{- end }}
+        {{- if .Annotations.description }}
+            {{ .Annotations.description }}
+        {{- end }}
+    {{- end }}
+{{- end }}
+
+
+
+{{- /* If none of the below matches, send to #monitoring-no-owner, and we 
+can then assign the expected code_owner to the alert or map the code_owner
+to the correct channel */ -}}
+{{ define "__get_channel_for_code_owner" -}}
+    {{- if eq . "platform-team" -}}
+        platform-alerts
+    {{- else if eq . "security-team" -}}
+        security-alerts
+    {{- else -}}
+        monitoring-no-owner
+    {{- end -}}
+{{- end }}
+
+{{- /* Select the channel based on the code_owner. We only expect to get
+into this template function if the code_owners label is present on an alert.
+This is to defend against us accidentally breaking the routing logic. */ -}}
+{{ define "slack.monzo.code_owner_channel" -}}
+    {{- if .CommonLabels.code_owner }}
+        {{ template "__get_channel_for_code_owner" .CommonLabels.code_owner }}
+    {{- else -}}
+        monitoring
+    {{- end }}
+{{- end }}
+
+{{ define "slack.monzo.link_button_text" -}}
+    {{- if .CommonAnnotations.link_text -}}
+        {{- .CommonAnnotations.link_text -}}
+    {{- else -}}
+        Link
+    {{- end }} :link:
+{{- end }}

--- a/terraform/modules/alertmanager/config/slack.tmpl
+++ b/terraform/modules/alertmanager/config/slack.tmpl
@@ -1,6 +1,10 @@
 # This builds the silence URL.  We exclude the alertname in the range
 # to avoid the issue of having trailing comma separator (%2C) at the end
 # of the generated URL
+#
+# This file was copied from https://gist.github.com/milesbxf/e2744fc90e9c41b47aa47925f8ff6512
+# Thank you :)
+
 {{ define "__alert_silence_link" -}}
     {{ .ExternalURL }}/#/silences/new?filter=%7B
     {{- range .CommonLabels.SortedPairs -}}

--- a/terraform/modules/alertmanager/config/slack.tmpl
+++ b/terraform/modules/alertmanager/config/slack.tmpl
@@ -15,10 +15,10 @@
 
 {{ define "__alert_severity_prefix" -}}
     {{ if ne .Status "firing" -}}
-    :lgtm:
-    {{- else if eq .Labels.severity "critical" -}}
+    :white_check_mark:
+    {{- else if eq .Labels.severity "high" -}}
     :fire:
-    {{- else if eq .Labels.severity "warning" -}}
+    {{- else if eq .Labels.severity "medium" -}}
     :warning:
     {{- else -}}
     :question:
@@ -27,12 +27,12 @@
 
 {{ define "__alert_severity_prefix_title" -}}
     {{ if ne .Status "firing" -}}
-    :lgtm:
-    {{- else if eq .CommonLabels.severity "critical" -}}
+    :white_check_mark:
+    {{- else if eq .CommonLabels.severity "high" -}}
     :fire:
-    {{- else if eq .CommonLabels.severity "warning" -}}
+    {{- else if eq .CommonLabels.severity "medium" -}}
     :warning:
-    {{- else if eq .CommonLabels.severity "info" -}}
+    {{- else if eq .CommonLabels.severity "low" -}}
     :information_source:
     {{- else -}}
     :question:
@@ -51,9 +51,9 @@
 {{/* Color of Slack attachment (appears as line next to alert )*/}}
 {{ define "slack.monzo.color" -}}
     {{ if eq .Status "firing" -}}
-        {{ if eq .CommonLabels.severity "warning" -}}
+        {{ if eq .CommonLabels.severity "medium" -}}
             warning
-        {{- else if eq .CommonLabels.severity "critical" -}}
+        {{- else if eq .CommonLabels.severity "high" -}}
             danger
         {{- else -}}
             #439FE0
@@ -63,52 +63,24 @@
     {{- end }}
 {{- end }}
 
+{{/* The test to display in the pretext */}}
+{{ define "slack.monzo.pretext" -}}
+    {{ range .Alerts }}
+        {{- if .Annotations.summary }}
+            *{{ .Annotations.summary }}*
+        {{- end }}
+    {{- end }}
+{{- end }}
 
-{{/* Emoji to display as user icon (custom emoji supported!) */}}
-{{ define "slack.monzo.icon_emoji" }}:prometheus:{{ end }}
 
 {{/* The test to display in the alert */}}
 {{ define "slack.monzo.text" -}}
-    {{ range .Alerts }}
-        {{- if .Annotations.message }}
-            {{ .Annotations.message }}
-        {{- end }}
-        {{- if .Annotations.description }}
-            {{ .Annotations.description }}
+    {{ if eq .Status "firing" -}}
+        {{ range .Alerts }}
+            {{- if .Annotations.description }}
+                {{ .Annotations.description }}
+            {{- end }}
         {{- end }}
     {{- end }}
 {{- end }}
 
-
-
-{{- /* If none of the below matches, send to #monitoring-no-owner, and we 
-can then assign the expected code_owner to the alert or map the code_owner
-to the correct channel */ -}}
-{{ define "__get_channel_for_code_owner" -}}
-    {{- if eq . "platform-team" -}}
-        platform-alerts
-    {{- else if eq . "security-team" -}}
-        security-alerts
-    {{- else -}}
-        monitoring-no-owner
-    {{- end -}}
-{{- end }}
-
-{{- /* Select the channel based on the code_owner. We only expect to get
-into this template function if the code_owners label is present on an alert.
-This is to defend against us accidentally breaking the routing logic. */ -}}
-{{ define "slack.monzo.code_owner_channel" -}}
-    {{- if .CommonLabels.code_owner }}
-        {{ template "__get_channel_for_code_owner" .CommonLabels.code_owner }}
-    {{- else -}}
-        monitoring
-    {{- end }}
-{{- end }}
-
-{{ define "slack.monzo.link_button_text" -}}
-    {{- if .CommonAnnotations.link_text -}}
-        {{- .CommonAnnotations.link_text -}}
-    {{- else -}}
-        Link
-    {{- end }} :link:
-{{- end }}

--- a/terraform/modules/alertmanager/input.tf
+++ b/terraform/modules/alertmanager/input.tf
@@ -4,6 +4,17 @@ variable monitoring_space_id {}
 
 variable config { default = "" }
 
+variable slack_url { default = "" }
+variable slack_channel { default = "" }
+
 locals {
-  config = var.config == "" ? file("${path.module}/config/alertmanager.yml") : var.config
+  map_variables = {
+    slack_url     = var.slack_url
+    slack_channel = var.slack_channel
+  }
+}
+
+locals {
+  config         = var.config == "" ? templatefile("${path.module}/config/alertmanager.yml", local.map_variables) : var.config
+  slack_template = file("${path.module}/config/slack.tmpl")
 }

--- a/terraform/modules/alertmanager/input.tf
+++ b/terraform/modules/alertmanager/input.tf
@@ -8,13 +8,13 @@ variable slack_url { default = "" }
 variable slack_channel { default = "" }
 
 locals {
-  map_variables = {
+  alertmanager_variables = {
     slack_url     = var.slack_url
     slack_channel = var.slack_channel
   }
 }
 
 locals {
-  config         = var.config == "" ? templatefile("${path.module}/config/alertmanager.yml", local.map_variables) : var.config
+  config         = var.config == "" ? templatefile("${path.module}/config/alertmanager.yml", local.alertmanager_variables) : var.config
   slack_template = file("${path.module}/config/slack.tmpl")
 }

--- a/terraform/modules/alertmanager/resources.tf
+++ b/terraform/modules/alertmanager/resources.tf
@@ -8,11 +8,12 @@ resource cloudfoundry_app alertmanager {
   name         = "alertmanager-${var.monitoring_instance_name}"
   space        = var.monitoring_space_id
   docker_image = "prom/alertmanager"
-  command      = "echo \"$${CONFIG}\" > alertmanager.yml ; alertmanager --web.listen-address=:$${PORT} --config.file=alertmanager.yml"
+  command      = "echo \"$${SLACK_TEMPLATE}\" > slack.tmpl; echo \"$${CONFIG}\" > alertmanager.yml ; alertmanager --web.listen-address=:$${PORT} --config.file=alertmanager.yml"
   routes {
     route = cloudfoundry_route.alertmanager.id
   }
   environment = {
-    CONFIG = local.config
+    CONFIG         = local.config
+    SLACK_TEMPLATE = local.slack_template
   }
 }

--- a/terraform/modules/grafana/datasources/prometheus.yml.tmpl
+++ b/terraform/modules/grafana/datasources/prometheus.yml.tmpl
@@ -3,13 +3,13 @@ apiVersion: 1
 
 # list of datasources that should be deleted from the database
 deleteDatasources:
-- name: Prometheus-${monitoring_instance_name}
+- name: Prometheus
   orgId: 1
 
 # list of datasources to insert/update depending
 # what's available in the database
 datasources:
-- name: Prometheus-${monitoring_instance_name}
+- name: Prometheus
   type: prometheus
   access: proxy
   orgId: 1


### PR DESCRIPTION
Provided a set of standard templates to make the alerts in slack neat, and provided the ability to pass a number of variables to the alert manager, which permitted the use of links on the slack message.