### PR TITLE
Revert "Update prometheus.yml.tmpl"

### DIFF
--- a/terraform/modules/grafana/datasources/prometheus.yml.tmpl
+++ b/terraform/modules/grafana/datasources/prometheus.yml.tmpl
@@ -3,13 +3,13 @@ apiVersion: 1
 
 # list of datasources that should be deleted from the database
 deleteDatasources:
-- name: Prometheus
+- name: Prometheus-${monitoring_instance_name}
   orgId: 1
 
 # list of datasources to insert/update depending
 # what's available in the database
 datasources:
-- name: Prometheus
+- name: Prometheus-${monitoring_instance_name}
   type: prometheus
   access: proxy
   orgId: 1


### PR DESCRIPTION
This reverts commit 87d8b9f1922a9412403e8d5914de5b5cc7ff12e9.
It breaks existing dashboards using the default datasource. It's also
more explicit to name the data source with the monitoring instance name.