### PR TITLE
Binding Service across spaces is not permitted

### DIFF
--- a/terraform/modules/redis_prometheus_exporter/resource.tf
+++ b/terraform/modules/redis_prometheus_exporter/resource.tf
@@ -15,9 +15,7 @@ resource cloudfoundry_app redis-exporter {
   routes {
     route = cloudfoundry_route.redis_exporter.id
   }
-  service_binding {
-    service_instance = var.redis_service_instance_id
-  }
+
   environment = {
     REDIS_ADDR                        = local.url
     REDIS_PASSWORD                    = cloudfoundry_service_key.redis-key.credentials.password


### PR DESCRIPTION
When deploying the monitoring in a different space to the application, the redis exporter would not bind across CF spaces. Since it has no need to be bound, the URL and credentials are passed in as Environment variables, this can be removed.
And it neatly keeps the exporter in a different space to the application.