### PR TITLE
Allow alertmanager Slack configuration when called from prometheus_all

### DIFF
--- a/terraform/modules/alertmanager/config/alertmanager.yml.tmpl
+++ b/terraform/modules/alertmanager/config/alertmanager.yml.tmpl
@@ -35,4 +35,4 @@ receivers:
     - type: button
       text: 'Silence :no_bell:'
       url: '{{ template "__alert_silence_link" . }}'
- %{ endif ~}
+%{ endif ~}

--- a/terraform/modules/alertmanager/input.tf
+++ b/terraform/modules/alertmanager/input.tf
@@ -12,9 +12,6 @@ locals {
     slack_url     = var.slack_url
     slack_channel = var.slack_channel
   }
-}
-
-locals {
   config         = var.config == "" ? templatefile("${path.module}/config/alertmanager.yml.tmpl", local.alertmanager_variables) : var.config
   slack_template = file("${path.module}/config/slack.tmpl")
 }

--- a/terraform/modules/alertmanager/input.tf
+++ b/terraform/modules/alertmanager/input.tf
@@ -6,7 +6,6 @@ variable config { default = "" }
 
 variable slack_url { default = "" }
 variable slack_channel { default = "" }
-
 locals {
   alertmanager_variables = {
     slack_url     = var.slack_url

--- a/terraform/modules/prometheus_all/input.tf
+++ b/terraform/modules/prometheus_all/input.tf
@@ -6,6 +6,8 @@ variable paas_exporter_username {}
 variable paas_exporter_password {}
 
 variable alertmanager_config { default = "" }
+variable alertmanager_slack_url { default = "" }
+variable alertmanager_slack_channel { default = "" }
 variable alert_rules { default = "" }
 
 variable grafana_google_client_id { default = "" }

--- a/terraform/modules/prometheus_all/resources.tf
+++ b/terraform/modules/prometheus_all/resources.tf
@@ -37,6 +37,8 @@ module alertmanager {
   monitoring_instance_name = var.monitoring_instance_name
   monitoring_space_id      = data.cloudfoundry_space.monitoring.id
   config                   = var.alertmanager_config
+  slack_url                = var.alertmanager_slack_url
+  slack_channel            = var.alertmanager_slack_channel
 }
 
 module grafana {

--- a/terraform/modules/redis_prometheus_exporter/resource.tf
+++ b/terraform/modules/redis_prometheus_exporter/resource.tf
@@ -17,8 +17,8 @@ resource cloudfoundry_app redis-exporter {
   }
 
   environment = {
-    REDIS_ADDR                        = local.url
-    REDIS_PASSWORD                    = cloudfoundry_service_key.redis-key.credentials.password
+    REDIS_ADDR     = local.url
+    REDIS_PASSWORD = cloudfoundry_service_key.redis-key.credentials.password
   }
 }
 


### PR DESCRIPTION
Extend `prometheus_all` module to allow passing of `slack_url` and `slack_channel` to `alertmanager` module
