### PR TITLE
Tune CF dashboard

### DIFF
--- a/terraform/modules/grafana/dashboards/cf_overview.json
+++ b/terraform/modules/grafana/dashboards/cf_overview.json
@@ -16,125 +16,10 @@
   "editable": true,
   "gnetId": 10063,
   "graphTooltip": 0,
-  "id": 6,
-  "iteration": 1605194665888,
+  "id": 2,
+  "iteration": 1609768744994,
   "links": [],
   "panels": [
-    {
-      "datasource": "Prometheus",
-      "fieldConfig": {
-        "defaults": {
-          "custom": {},
-          "mappings": [],
-          "thresholds": {
-            "mode": "absolute",
-            "steps": [
-              {
-                "color": "green",
-                "value": null
-              },
-              {
-                "color": "red",
-                "value": 80
-              }
-            ]
-          }
-        },
-        "overrides": []
-      },
-      "gridPos": {
-        "h": 3,
-        "w": 4,
-        "x": 0,
-        "y": 0
-      },
-      "id": 6,
-      "options": {
-        "colorMode": "value",
-        "graphMode": "none",
-        "justifyMode": "auto",
-        "orientation": "auto",
-        "reduceOptions": {
-          "calcs": [
-            "mean"
-          ],
-          "fields": "",
-          "values": false
-        },
-        "textMode": "auto"
-      },
-      "pluginVersion": "7.2.2",
-      "targets": [
-        {
-          "expr": "count( memory_utilization{space=\"$SpaceName\" , app=~\"$Applications\" , exported_instance=\"0\"})",
-          "interval": "",
-          "legendFormat": "",
-          "refId": "A"
-        }
-      ],
-      "timeFrom": null,
-      "timeShift": null,
-      "title": "Applications",
-      "type": "stat"
-    },
-    {
-      "datasource": "Prometheus",
-      "description": "",
-      "fieldConfig": {
-        "defaults": {
-          "custom": {},
-          "mappings": [],
-          "thresholds": {
-            "mode": "absolute",
-            "steps": [
-              {
-                "color": "green",
-                "value": null
-              },
-              {
-                "color": "red",
-                "value": 80
-              }
-            ]
-          }
-        },
-        "overrides": []
-      },
-      "gridPos": {
-        "h": 3,
-        "w": 4,
-        "x": 4,
-        "y": 0
-      },
-      "id": 8,
-      "options": {
-        "colorMode": "value",
-        "graphMode": "none",
-        "justifyMode": "auto",
-        "orientation": "auto",
-        "reduceOptions": {
-          "calcs": [
-            "first"
-          ],
-          "fields": "",
-          "values": false
-        },
-        "textMode": "auto"
-      },
-      "pluginVersion": "7.2.2",
-      "targets": [
-        {
-          "expr": "count(connections{ space=\"$SpaceName\" })",
-          "interval": "",
-          "legendFormat": "",
-          "refId": "A"
-        }
-      ],
-      "timeFrom": null,
-      "timeShift": null,
-      "title": "Databases",
-      "type": "stat"
-    },
     {
       "activePatternIndex": 1,
       "datasource": "Prometheus",
@@ -228,11 +113,12 @@
       },
       "gridPos": {
         "h": 6,
-        "w": 11,
-        "x": 12,
+        "w": 13,
+        "x": 0,
         "y": 0
       },
       "id": 12,
+      "options": {},
       "patterns": [
         {
           "bgColors": "green|orange|red",
@@ -355,7 +241,7 @@
       "pluginVersion": "7.2.2",
       "row_col_wrapper": "_",
       "sorting_props": {
-        "col_index": 0,
+        "col_index": 1,
         "direction": "asc"
       },
       "targets": [
@@ -391,24 +277,17 @@
       "dashLength": 10,
       "dashes": false,
       "datasource": "Prometheus",
-      "fieldConfig": {
-        "defaults": {
-          "custom": {}
-        },
-        "overrides": []
-      },
       "fill": 1,
       "fillGradient": 0,
       "gridPos": {
-        "h": 6,
+        "h": 7,
         "w": 23,
         "x": 0,
         "y": 6
       },
       "hiddenSeries": false,
-      "id": 10,
+      "id": 14,
       "legend": {
-        "alignAsTable": true,
         "avg": false,
         "current": false,
         "max": false,
@@ -421,32 +300,42 @@
       "linewidth": 1,
       "nullPointMode": "null",
       "options": {
-        "alertThreshold": true
+        "dataLinks": []
       },
       "percentage": false,
-      "pluginVersion": "7.2.2",
       "pointradius": 2,
       "points": false,
       "renderer": "flot",
-      "seriesOverrides": [],
+      "seriesOverrides": [
+        {
+          "alias": "/.*failed requests/",
+          "color": "#C4162A"
+        },
+        {
+          "alias": "/.*total requests/",
+          "color": "#1F60C4"
+        }
+      ],
       "spaceLength": 10,
       "stack": false,
       "steppedLine": false,
       "targets": [
         {
-          "expr": "sum by ( app ) ( disk_bytes{ space=\"$SpaceName\" , app=~\"$Applications\" })",
-          "format": "time_series",
-          "instant": false,
-          "interval": "",
-          "legendFormat": "{{app}} ",
+          "expr": "sum(rate(requests{app=~\"$Applications\"}[5m])) by (app) *60",
+          "legendFormat": "{{app}} total requests",
           "refId": "A"
+        },
+        {
+          "expr": "sum(rate(requests{app=~\"$Applications\",status_range=~\"0xx|4xx|5xx\"}[5m])) by (app) *60",
+          "legendFormat": "{{app}} failed requests",
+          "refId": "B"
         }
       ],
       "thresholds": [],
       "timeFrom": null,
       "timeRegions": [],
       "timeShift": null,
-      "title": "Disk Usage",
+      "title": "HTTP requests",
       "tooltip": {
         "shared": true,
         "sort": 0,
@@ -462,7 +351,6 @@
       },
       "yaxes": [
         {
-          "$$hashKey": "object:3161",
           "format": "short",
           "label": null,
           "logBase": 1,
@@ -471,7 +359,93 @@
           "show": true
         },
         {
-          "$$hashKey": "object:3162",
+          "format": "short",
+          "label": null,
+          "logBase": 1,
+          "max": null,
+          "min": null,
+          "show": true
+        }
+      ],
+      "yaxis": {
+        "align": false,
+        "alignLevel": null
+      }
+    },
+    {
+      "aliasColors": {},
+      "bars": false,
+      "dashLength": 10,
+      "dashes": false,
+      "datasource": "Prometheus",
+      "fill": 1,
+      "fillGradient": 0,
+      "gridPos": {
+        "h": 7,
+        "w": 23,
+        "x": 0,
+        "y": 13
+      },
+      "hiddenSeries": false,
+      "id": 16,
+      "legend": {
+        "avg": false,
+        "current": false,
+        "max": false,
+        "min": false,
+        "show": true,
+        "total": false,
+        "values": false
+      },
+      "lines": true,
+      "linewidth": 1,
+      "nullPointMode": "null",
+      "options": {
+        "dataLinks": []
+      },
+      "percentage": false,
+      "pointradius": 2,
+      "points": false,
+      "renderer": "flot",
+      "seriesOverrides": [],
+      "spaceLength": 10,
+      "stack": false,
+      "steppedLine": false,
+      "targets": [
+        {
+          "expr": "avg(rate(response_time_sum{app=~\"$Applications\"}[1m])) by (app)",
+          "legendFormat": "{{app}}",
+          "refId": "A"
+        }
+      ],
+      "thresholds": [],
+      "timeFrom": null,
+      "timeRegions": [],
+      "timeShift": null,
+      "title": "Response time (seconds)",
+      "tooltip": {
+        "shared": true,
+        "sort": 0,
+        "value_type": "individual"
+      },
+      "type": "graph",
+      "xaxis": {
+        "buckets": null,
+        "mode": "time",
+        "name": null,
+        "show": true,
+        "values": []
+      },
+      "yaxes": [
+        {
+          "format": "short",
+          "label": null,
+          "logBase": 1,
+          "max": null,
+          "min": null,
+          "show": true
+        },
+        {
           "format": "short",
           "label": null,
           "logBase": 1,
@@ -501,10 +475,10 @@
       "fill": 1,
       "fillGradient": 0,
       "gridPos": {
-        "h": 5,
+        "h": 7,
         "w": 23,
         "x": 0,
-        "y": 12
+        "y": 20
       },
       "hiddenSeries": false,
       "id": 4,
@@ -521,7 +495,8 @@
       "linewidth": 1,
       "nullPointMode": "null",
       "options": {
-        "alertThreshold": true
+        "alertThreshold": true,
+        "dataLinks": []
       },
       "percentage": false,
       "pluginVersion": "7.2.2",
@@ -534,9 +509,9 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "cpu{space=\"$SpaceName\" , app=~\"$Applications\" }",
+          "expr": "avg(cpu{space=\"$SpaceName\" , app=~\"$Applications\" }) by (app)",
           "interval": "",
-          "legendFormat": "{{app}} Instance {{exported_instance}}",
+          "legendFormat": "{{app}}",
           "refId": "A"
         }
       ],
@@ -544,7 +519,7 @@
       "timeFrom": null,
       "timeRegions": [],
       "timeShift": null,
-      "title": "CPU Usage",
+      "title": "CPU Usage (%)",
       "tooltip": {
         "shared": true,
         "sort": 0,
@@ -563,8 +538,8 @@
           "format": "short",
           "label": null,
           "logBase": 1,
-          "max": null,
-          "min": null,
+          "max": "100",
+          "min": "0",
           "show": true
         },
         {
@@ -597,10 +572,10 @@
       "fill": 1,
       "fillGradient": 0,
       "gridPos": {
-        "h": 5,
+        "h": 7,
         "w": 23,
         "x": 0,
-        "y": 17
+        "y": 27
       },
       "hiddenSeries": false,
       "id": 2,
@@ -617,7 +592,8 @@
       "linewidth": 1,
       "nullPointMode": "null",
       "options": {
-        "alertThreshold": true
+        "alertThreshold": true,
+        "dataLinks": []
       },
       "percentage": false,
       "pluginVersion": "7.2.2",
@@ -630,9 +606,9 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "memory_utilization{space=\"$SpaceName\" , app=~\"$Applications\" }",
+          "expr": "avg(memory_utilization{space=\"$SpaceName\" , app=~\"$Applications\" }) by (app)",
           "interval": "",
-          "legendFormat": "{{app}}  Instance {{exported_instance}}",
+          "legendFormat": "{{app}}",
           "refId": "A"
         }
       ],
@@ -676,10 +652,109 @@
         "align": false,
         "alignLevel": null
       }
+    },
+    {
+      "aliasColors": {},
+      "bars": false,
+      "dashLength": 10,
+      "dashes": false,
+      "datasource": "Prometheus",
+      "fieldConfig": {
+        "defaults": {
+          "custom": {}
+        },
+        "overrides": []
+      },
+      "fill": 1,
+      "fillGradient": 0,
+      "gridPos": {
+        "h": 7,
+        "w": 23,
+        "x": 0,
+        "y": 34
+      },
+      "hiddenSeries": false,
+      "id": 10,
+      "legend": {
+        "alignAsTable": false,
+        "avg": false,
+        "current": false,
+        "max": false,
+        "min": false,
+        "show": true,
+        "total": false,
+        "values": false
+      },
+      "lines": true,
+      "linewidth": 1,
+      "nullPointMode": "null",
+      "options": {
+        "alertThreshold": true,
+        "dataLinks": []
+      },
+      "percentage": false,
+      "pluginVersion": "7.2.2",
+      "pointradius": 2,
+      "points": false,
+      "renderer": "flot",
+      "seriesOverrides": [],
+      "spaceLength": 10,
+      "stack": false,
+      "steppedLine": false,
+      "targets": [
+        {
+          "expr": "avg by ( app ) ( disk_utilization{ space=\"$SpaceName\" , app=~\"$Applications\" })",
+          "format": "time_series",
+          "instant": false,
+          "interval": "",
+          "legendFormat": "{{app}} ",
+          "refId": "A"
+        }
+      ],
+      "thresholds": [],
+      "timeFrom": null,
+      "timeRegions": [],
+      "timeShift": null,
+      "title": "Disk Usage (%)",
+      "tooltip": {
+        "shared": true,
+        "sort": 0,
+        "value_type": "individual"
+      },
+      "type": "graph",
+      "xaxis": {
+        "buckets": null,
+        "mode": "time",
+        "name": null,
+        "show": true,
+        "values": []
+      },
+      "yaxes": [
+        {
+          "format": "short",
+          "label": null,
+          "logBase": 1,
+          "max": "100",
+          "min": "0",
+          "show": true
+        },
+        {
+          "format": "short",
+          "label": null,
+          "logBase": 1,
+          "max": null,
+          "min": null,
+          "show": true
+        }
+      ],
+      "yaxis": {
+        "align": false,
+        "alignLevel": null
+      }
     }
   ],
-  "refresh": "5s",
-  "schemaVersion": 26,
+  "refresh": "10s",
+  "schemaVersion": 21,
   "style": "dark",
   "tags": [],
   "templating": {
@@ -687,7 +762,6 @@
       {
         "allValue": null,
         "current": {
-          "selected": false,
           "text": "dfe-teacher-services",
           "value": "dfe-teacher-services"
         },
@@ -713,9 +787,8 @@
       {
         "allValue": null,
         "current": {
-          "selected": false,
-          "text": "get-into-teaching",
-          "value": "get-into-teaching"
+          "text": "teaching-vacancies-production",
+          "value": "teaching-vacancies-production"
         },
         "datasource": "Prometheus",
         "definition": "label_values(memory_utilization{organisation =~\"$OrgName\"},space)",
@@ -740,6 +813,7 @@
         "allValue": null,
         "current": {
           "selected": false,
+          "tags": [],
           "text": "All",
           "value": "$__all"
         },
@@ -765,7 +839,7 @@
     ]
   },
   "time": {
-    "from": "now-5m",
+    "from": "now-1h",
     "to": "now"
   },
   "timepicker": {
@@ -794,7 +868,7 @@
     ]
   },
   "timezone": "",
-  "title": "CF Overview2",
+  "title": "CF apps",
   "uid": "eF19g4RZx",
   "version": 1
 }


### PR DESCRIPTION
## What
- Remove stat panels for compatibility with grafana 6
- Change to disk utilization as percentage for easier visualisation
- Change percent metrics axis from 0 to 100 to show scale more
  explicitly
- Rename dashboard to CF apps
- Add HTTP throughput graph
- Add HTTP response time graph

## Review
This was tested on teaching vacancies

![Screenshot 2021-01-04 at 15 14 51](https://user-images.githubusercontent.com/8416694/103549828-e2fe1100-4e9f-11eb-940a-747e61a76251.png)
