### PR TITLE
Add optional parameter for specifying the postgres server storage.

### DIFF
--- a/templates/postgresql-server.json
+++ b/templates/postgresql-server.json
@@ -12,12 +12,16 @@
       "type": "int",
       "defaultValue": 2
     },
+    "dbStorageMB" : {
+      "type": "int",
+      "defaultValue": 5120
+    },    
      "postgresSku": {
        "type": "object",
        "defaultValue": {
        "name": "[concat('GP_Gen5_', parameters('dbServerCpuCores'))]",
        "tier": "GeneralPurpose",
-       "size": 5120,
+       "size": "[parameters('dbStorageMB')]",
        "family": "Gen5",
        "capacity": "[parameters('dbServerCpuCores')]"
     }


### PR DESCRIPTION
Add optional parameter for specifying the postgres server storage.

Prod servers are set to autogrow and once the size has grown, it should be the same in the next ARM deployment.
So adding parameter to specify the value,