### PR TITLE
use VISUAL or EDITOR if avaiable before vi

### DIFF
--- a/scripts/fetch_config/fetch_config.rb
+++ b/scripts/fetch_config/fetch_config.rb
@@ -10,7 +10,7 @@ require 'json'
 ALLOWED_SOURCES = ['aws-ssm-parameter', 'aws-ssm-parameter-path', 'yaml-file', 'azure-key-vault-secret']
 ALLOWED_DESTINATION = ['stdout', 'file', 'command', 'quiet', 'azure-key-vault-secret']
 ALLOWED_FORMATS = ['hash', 'shell-env-var', 'tf-shell-env-var', 'yaml', 'json']
-EDITOR = 'vim'
+EDITOR = ENV.fetch('VISUAL', ENV.fetch('EDITOR', 'vi'))
 
 @log = Logger.new(STDOUT)
 @log.level = Logger::INFO


### PR DESCRIPTION
Users may set their editor using `VISUAL` or `EDITOR`. Respect those if so, use `vi` otherwise.