### PR TITLE
Read Key Vault name from environment variable

### DIFF
--- a/scripts/fetch_config/fetch_config.rb
+++ b/scripts/fetch_config/fetch_config.rb
@@ -53,6 +53,7 @@ def collect_source(arg)
   @log.debug "Extract source from #{arg}"
   source_type, source_parameter = arg.split(':')
   usage unless ALLOWED_SOURCES.include? source_type
+  source_parameter = "#{ENV['key_vault_name']}/#{ENV['key_vault_app_secret_name']}" if source_parameter.nil? && source_type == 'azure-key-vault-secret'
   usage unless source_parameter
   new_source = {source_type => [source_parameter]}
   @log.debug "Collecting #{new_source}"
@@ -63,9 +64,9 @@ def extract_destination(arg)
   @log.debug "Extract destination from #{arg}"
   destination_type, destination_parameter = arg.split(':')
   usage unless ALLOWED_DESTINATION.include? destination_type
-  usage if ! destination_parameter && (
-    destination_type == 'file' || destination_type == 'azure-key-vault-secret'
-  )
+  usage if ! destination_parameter && destination_type == 'file'
+  destination_parameter = "#{ENV['key_vault_name']}/#{ENV['key_vault_app_secret_name']}" if destination_parameter.nil? && destination_type == 'azure-key-vault-secret'
+  @log.debug "destination_parameter is #{destination_parameter}"
   new_destination = {type: destination_type, parameter: destination_parameter}
   @log.debug "Found destination #{new_destination}"
   new_destination

--- a/scripts/fetch_config/fetch_config.rb
+++ b/scripts/fetch_config/fetch_config.rb
@@ -23,14 +23,16 @@ def usage
       aws-ssm-parameter:<parameter-name> aws-ssm-parameter name in AWS SSM Parameter store
       aws-ssm-parameter-path:<parameter-path> parameter path in AWS SSM Parameter store hierarchy
       yaml-file:<path> path to yaml file containing parameters
-      azure-key-vault-secret:<keyvault/secret> secret in Azure key vault
+      azure-key-vault-secret[:<keyvault-name/secret-name>] secret in Azure key vault
+      if keyvault-name and secret-name are not specified, the values are read from 'key_vault_name' and 'key_vault_app_secret_name' environment variables
     -e (--edit): open editor to edit variables manually before output
     -d (--destination): Destination of variables
       stdout (default) : Write to standard out
       file:<path> : Write to file at <path>
       command : Run command in environment populated by the variables. Requires '-- <command>' at the end of the line
       quiet : No output (Validates input)
-      azure-key-vault-secret:<keyvault/secret> : Secret in Azure key vault
+      azure-key-vault-secret[:<keyvault-name/secret-name>] : Secret in Azure key vault
+      if keyvault-name and secret-name are not specified, the values are read from 'key_vault_name' and 'key_vault_app_secret_name' environment variables
     -f (--format): Output format
       hash (default): Raw ruby hash {KEY => VALUE}
       shell-env-var: Standard shell environment variables KEY=VALUE (Not for nested variables)


### PR DESCRIPTION
read `key_vault_name` and `key_vault_app_secret_name` from tf vars file

All ruby apps have the `dotenv` gem and the `tfvars` file follows a `"Key = Value"` format similar to a `.env` file, 
dotenv can be used to parse variables inside a `tfvars` file and set a `ENV` variables.
There is no need to maintain a separate shell script to set the keyvault name as environment variables.

This allows the below usage inside a makefile

```shell
bundle exec dotenv -f terraform/workspace_variables/$(app_env).tfvars bin/fetch_config.rb -s azure-key-vault-secret -f yaml
# example:
bundle exec dotenv -f terraform/workspace_variables/qa.tfvars bin/fetch_config.rb -s azure-key-vault-secret -f yaml
```