### PR TITLE
allow custom editor env to use args

### DIFF
--- a/scripts/fetch_config/fetch_config.rb
+++ b/scripts/fetch_config/fetch_config.rb
@@ -324,6 +324,8 @@ opts.each do |opt, arg|
   end
 end
 
+@log.level = Logger::DEBUG if ENV['FETCH_CONFIG_VERBOSE']
+
 ##### Validation #####
 usage if sources.empty?
 

--- a/scripts/fetch_config/fetch_config.rb
+++ b/scripts/fetch_config/fetch_config.rb
@@ -6,6 +6,7 @@ require 'erb'
 require 'tempfile'
 require 'net/http'
 require 'json'
+require 'shellwords'
 
 ALLOWED_SOURCES = ['aws-ssm-parameter', 'aws-ssm-parameter-path', 'yaml-file', 'azure-key-vault-secret']
 ALLOWED_DESTINATION = ['stdout', 'file', 'command', 'quiet', 'azure-key-vault-secret']
@@ -263,8 +264,9 @@ def open_in_editor(config_map)
   Tempfile.create { |f|
     YAML.dump(config_map, f)
     f.rewind
-    @log.debug "Opening file #{f.path} with editor: #{EDITOR}"
-    system(EDITOR, f.path)
+    cmd = "#{EDITOR} #{Shellwords.escape(f.path)}"
+    @log.debug "Editing config file: #{cmd}"
+    raise "Editor error: #{$?}" unless system(cmd)
     new_map = YAML.load_file(f.path)
   }
   new_map


### PR DESCRIPTION
Before, when EDITOR/VISUAL was set to an editor with args the system
call here would fail silently. Take the custom EDITOR as an example:
"emacs -nw -q" (aside: -nw means run in term without GUI and -q means
don't load init files, these are fully reasonable args). Running
fetch_config.rb with -e would fail silently because it would try to run
the shell command "emacs\ -nw\ -q <temp-config-file>".

This change allows "emacs -nw -q" to be parsed as expected, while
escaping any special shell chars in <temp-config-file> just in
case (unlikely, but who know with OSX).

