### PR TITLE
Post-rubocop bugfix

### DIFF
--- a/scripts/fetch_config/fetch_config.rb
+++ b/scripts/fetch_config/fetch_config.rb
@@ -252,7 +252,7 @@ end
 def stringify(config_map)
   @log.debug 'Converting non string values to strings'
 
-  config_map.transform_keys do |k|
+  config_map.transform_keys do |k,v|
     if config_map[v].is_a?(Hash) || config_map[v].is_a?(Array)
       error_exit "Error: This format does not accept nested variables: #{k}: #{config_map(v)}"
     end
@@ -265,7 +265,7 @@ def sort_by_key(config_map)
   config_map.sort.to_h
 end
 
-def env_var_list
+def env_var_list(config_map)
   shell_template = <<~TEMPLATE
     <% for k,v in config_map %><%= k %>=<%= v %>
     <% end %>


### PR DESCRIPTION
## What
Fixes for issues:

```
bin/fetch_config.rb:268:in `env_var_list': wrong number of arguments (given 1, expected 0) (ArgumentError)
	from bin/fetch_config.rb:381:in `<main>'
```
and

```
bin/fetch_config.rb:256:in `block in stringify': undefined local variable or method `v' for main:Object (NameError)
	from bin/fetch_config.rb:255:in `transform_keys'
	from bin/fetch_config.rb:255:in `stringify'
	from bin/fetch_config.rb:380:in `<main>'
```
We may have to run rubocop again and fix better.